### PR TITLE
Adding dedicated claim dialect support

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
@@ -38,6 +38,8 @@ public class OIDCAuthenticatorConstants {
     public static final String OAUTH2_AUTHZ_URL = "OAuth2AuthzEPUrl";
     public static final String OAUTH2_TOKEN_URL = "OAuth2TokenEPUrl";
 
+    public static final String OIDC_CLAIM_DIALECT_URI = "http://wso2.org/oidc/claim";
+
     public class AuthenticatorConfParams {
         private AuthenticatorConfParams() {
         }

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -579,7 +579,12 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
 
     @Override
     public String getClaimDialectURI() {
-        return "http://wso2.org/oidc/claim";
+        String claimDialectUri = super.getClaimDialectURI();
+        if (StringUtils.isNotEmpty(claimDialectUri)) {
+            return claimDialectUri;
+        } else {
+            return OIDCAuthenticatorConstants.OIDC_CLAIM_DIALECT_URI;
+        }
     }
 
 

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -194,6 +194,11 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                 String key = data.getKey();
                 Object value = data.getValue();
 
+                String claimDialectUri = getClaimDialectURI();
+                if (!OIDCAuthenticatorConstants.OIDC_CLAIM_DIALECT_URI.equals(claimDialectUri)) {
+                    key = claimDialectUri + "/" + key;
+                }
+
                 if (value != null) {
                     claims.put(ClaimMapping.build(key, key, null, false), value.toString());
                 }
@@ -478,6 +483,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
     protected void buildClaimMappings(Map<ClaimMapping, String> claims, Map.Entry<String, Object> entry, String
             separator) {
         String claimValue = null;
+        String claimUri   = "";
         if (StringUtils.isBlank(separator)) {
             separator = IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR_DEFAULT;
         }
@@ -498,11 +504,16 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
             claimValue = entry.getValue().toString();
         }
 
-        claims.put(ClaimMapping.build(entry.getKey(), entry.getKey(), null, false), claimValue);
-        if (log.isDebugEnabled() && IdentityUtil.isTokenLoggable(IdentityConstants.IdentityTokens.USER_CLAIMS)) {
-            log.debug("Adding claim mapping : " + entry.getKey() + " <> " + entry.getKey() + " : " + claimValue);
+        String claimDialectUri = getClaimDialectURI();
+        if (!OIDCAuthenticatorConstants.OIDC_CLAIM_DIALECT_URI.equals(claimDialectUri)) {
+            claimUri = claimDialectUri + "/";
         }
 
+        claimUri += entry.getKey();
+        claims.put(ClaimMapping.build(claimUri, claimUri, null, false), claimValue);
+        if (log.isDebugEnabled() && IdentityUtil.isTokenLoggable(IdentityConstants.IdentityTokens.USER_CLAIMS)) {
+            log.debug("Adding claim mapping : " + claimUri + " <> " + claimUri + " : " + claimValue);
+        }
     }
 
     private OAuthClientRequest getAccessRequest(String tokenEndPoint, String clientId, String code, String clientSecret,


### PR DESCRIPTION
This PR intends to add dedicated claim dialect support other than it's generic behavior of using OIDC claim dialect. This can be configured by adding following configuration to application-authentication.xml

ex:- &lt;Parameter name="ClaimDialectUri"&gt;&lt;claim_dialect_uri&gt; &lt;/Parameter&gt;
        For google, claim_dialect_uri can be like http://wso2.org/google/claims

public JIRA :- https://wso2.org/jira/browse/IDENTITY-6239
