### PR TITLE
Change target version to java7 to ensure backward compatibility with IS 5.3.0

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -28,6 +28,7 @@ import org.apache.oltu.oauth2.client.response.OAuthClientResponse;
 import org.apache.oltu.oauth2.client.response.OAuthJSONAccessTokenResponse;
 import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
+import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
@@ -335,7 +336,8 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
                 (claimMetadataManagementService);
         when(mockAuthenticationContext.getExternalIdP()).thenReturn(externalIdPConfig);
         whenNew(OAuthClient.class).withAnyArguments().thenReturn(mockOAuthClient);
-        when(mockOAuthClient.accessToken(anyObject())).thenReturn(mockOAuthJSONAccessTokenResponse);
+        when(mockOAuthClient.accessToken(Matchers.<OAuthClientRequest>anyObject()))
+                .thenReturn(mockOAuthJSONAccessTokenResponse);
         when(mockOAuthJSONAccessTokenResponse.getParam(anyString())).thenReturn(idToken);
         openIDConnectAuthenticator.processAuthenticationResponse(mockServletRequest,
                 mockServletResponse, mockAuthenticationContext);
@@ -368,7 +370,7 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
                 (claimMetadataManagementService);
         when(mockAuthenticationContext.getExternalIdP()).thenReturn(externalIdPConfig);
         whenNew(OAuthClient.class).withAnyArguments().thenReturn(mockOAuthClient);
-        when(mockOAuthClient.accessToken(anyObject())).thenReturn(mockOAuthJSONAccessTokenResponse);
+        when(mockOAuthClient.accessToken(Matchers.<OAuthClientRequest>anyObject())).thenReturn(mockOAuthJSONAccessTokenResponse);
         when(mockOAuthJSONAccessTokenResponse.getParam(anyString())).thenReturn(idToken);
         openIDConnectAuthenticator.processAuthenticationResponse(mockServletRequest,
                 mockServletResponse, mockAuthenticationContext);
@@ -386,7 +388,8 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
                 (claimMetadataManagementService);
         when(mockAuthenticationContext.getExternalIdP()).thenReturn(externalIdPConfig);
         whenNew(OAuthClient.class).withAnyArguments().thenReturn(mockOAuthClient);
-        when(mockOAuthClient.accessToken(anyObject())).thenReturn(mockOAuthJSONAccessTokenResponse);
+        when(mockOAuthClient.accessToken(Matchers.<OAuthClientRequest>anyObject()))
+                .thenReturn(mockOAuthJSONAccessTokenResponse);
         when(mockOAuthJSONAccessTokenResponse.getParam(anyString())).thenReturn(idToken);
         openIDConnectAuthenticator.processAuthenticationResponse(mockServletRequest,
                 mockServletResponse, mockAuthenticationContext);

--- a/pom.xml
+++ b/pom.xml
@@ -273,8 +273,8 @@
                 <inherited>true</inherited>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
### Proposed changes in this pull request
- We need to be able to run this connector on IS 5.3.0 as well. IS 5.3.0 supports both Java7 and Java8. Therefore fixing the target version to java 1.7 until we come to clear conclusion on how we are going to move to Java8.

