### PR TITLE
fixed NullPointerException that occurred when claims contain null value

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -527,13 +527,13 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
             }
         } catch (Exception e) {
             if (log.isDebugEnabled()) {
-                log.debug("Error while mapping " + entry.getKey() + " with value " + entry.getValue(), e);
+                log.debug("Error while mapping: " + entry.getKey() + " with value: " + entry.getValue(), e);
             }
             claimValue = entry.getValue() != null ? new StringBuilder(entry.getValue().toString()) : new StringBuilder();
         }
 
         claims.put(ClaimMapping.build(entry.getKey(), entry.getKey(), null, false),
-                claimValue != null ? claimValue.toString() : null);
+                claimValue != null ? claimValue.toString() : StringUtils.EMPTY);
         if (log.isDebugEnabled() && IdentityUtil.isTokenLoggable(IdentityConstants.IdentityTokens.USER_CLAIMS)) {
             log.debug("Adding claim mapping : " + entry.getKey() + " <> " + entry.getKey() + " : " + claimValue);
         }

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -526,8 +526,8 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
 
             }
         } catch (Exception e) {
-            if (log.isTraceEnabled()) {
-                log.trace("Error while mapping " + entry.getKey() + " with value " + entry.getValue(), e);
+            if (log.isDebugEnabled()) {
+                log.debug("Error while mapping " + entry.getKey() + " with value " + entry.getValue(), e);
             }
             claimValue = entry.getValue() != null ? new StringBuilder(entry.getValue().toString()) : new StringBuilder();
         }

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -514,7 +514,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         }
         try {
             JSONArray jsonArray = (JSONArray)JSONValue.parseWithException(entry.getValue().toString());
-            if (jsonArray != null && jsonArray.size() > 0) {
+            if (jsonArray != null && !jsonArray.isEmpty()) {
                 Iterator attributeIterator = jsonArray.iterator();
                 while (attributeIterator.hasNext()) {
                     if (claimValue == null) {
@@ -526,10 +526,14 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
 
             }
         } catch (Exception e) {
-            claimValue = new StringBuilder(entry.getValue().toString());
+            if (log.isTraceEnabled()) {
+                log.trace("Error while mapping " + entry.getKey() + " with value " + entry.getValue(), e);
+            }
+            claimValue = entry.getValue() != null ? new StringBuilder(entry.getValue().toString()) : new StringBuilder();
         }
 
-        claims.put(ClaimMapping.build(entry.getKey(), entry.getKey(), null, false), claimValue.toString());
+        claims.put(ClaimMapping.build(entry.getKey(), entry.getKey(), null, false),
+                claimValue != null ? claimValue.toString() : null);
         if (log.isDebugEnabled() && IdentityUtil.isTokenLoggable(IdentityConstants.IdentityTokens.USER_CLAIMS)) {
             log.debug("Adding claim mapping : " + entry.getKey() + " <> " + entry.getKey() + " : " + claimValue);
         }

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -432,7 +432,7 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
             openIDConnectAuthenticator.buildClaimMappings(claims, entry, null);
             assertNotNull(claims.get(
                     ClaimMapping.build(entry.getKey(), entry.getKey(), null, false)),
-                    "Claim was not mapped.");
+                    "Claim value is null.");
         }
     }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -417,6 +417,25 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
         }
     }
 
+    /**
+     * Covers a case that was experienced while mapping claims from Salesforce
+     */
+    @Test
+    public void testClaimMappingWithNullValues() {
+        Map<ClaimMapping, String> claims = new HashMap<>();
+        Map<String, Object> entries = new HashMap<>();
+        entries.put("zoneinfo", "GMT");
+        entries.put("email", "test123@test.de");
+        entries.put("phone_number", null);
+
+        for (Map.Entry<String, Object> entry : entries.entrySet()) {
+            openIDConnectAuthenticator.buildClaimMappings(claims, entry, null);
+            assertNotNull(claims.get(
+                    ClaimMapping.build(entry.getKey(), entry.getKey(), null, false)),
+                    "Claim was not mapped.");
+        }
+    }
+
     @Test(dataProvider = "requestDataHandler")
     public void testGetContextIdentifier(String grantType, String state, String loginType, String error, String expectedCanHandler, String expectedContext, String msgCanHandler, String msgContext) throws Exception {
         when(mockServletRequest.getParameter(OIDCAuthenticatorConstants.OAUTH2_GRANT_TYPE_CODE)).thenReturn(grantType);


### PR DESCRIPTION
### Proposed changes in this pull request

While experimenting with federated authentication using a Salesforce instance, we received a token like this:
`{at_hash=xxx, sub=https://test.salesforce.com/id/xxx/xxx, zoneinfo=GMT, email_verified=true, address={}, profile=https://xxxx, iss=https://xxxx, preferred_username=first.last@email.de, given_name=First, locale=de_DE_EURO, picture=https://xxx/img/userprofile/default_profile_200_v2.png,  aud=xxx, updated_at=2018-10-09T07:01:23Z, nickname=xxx, name=First Last, phone_number=null, exp=1539068692, iat=1539068572, family_name=Last, email=first.last@email.de}`

The claims mapping results in an authentication error caused by the following expection:
```
ERROR {org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.DefaultRequestCoordinator} -  Exception in Authentication Framework
java.lang.NullPointerException
        at org.wso2.carbon.identity.application.authenticator.oidc.OpenIDConnectAuthenticator.buildClaimMappings(OpenIDConnectAuthenticator.java:529)
        at org.wso2.carbon.identity.application.authenticator.oidc.OpenIDConnectAuthenticator.processAuthenticationResponse(OpenIDConnectAuthenticator.java:402)
        at org.wso2.carbon.identity.application.authentication.framework.AbstractApplicationAuthenticator.process(AbstractApplicationAuthenticator.java:77)
        at org.wso2.carbon.identity.application.authentication.framework.handler.step.impl.DefaultStepHandler.doAuthentication(DefaultStepHandler.java:490)
        at org.wso2.carbon.identity.application.authentication.framework.handler.step.impl.DefaultStepHandler.handleResponse(DefaultStepHandler.java:464)
        at org.wso2.carbon.identity.application.authentication.framework.handler.step.impl.DefaultStepHandler.handle(DefaultStepHandler.java:167)
        at org.wso2.carbon.identity.application.authentication.framework.handler.sequence.impl.DefaultStepBasedSequenceHandler.handle(DefaultStepBasedSequenceHandler.java:188)
        at org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.DefaultAuthenticationRequestHandler.handle(DefaultAuthenticationRequestHandler.java:132)
        at org.wso2.carbon.identity.application.authentication.framework.handler.request.impl.DefaultRequestCoordinator.handle(DefaultRequestCoordinator.java:159)
        at org.wso2.carbon.identity.application.authentication.framework.servlet.CommonAuthenticationServlet.doPost(CommonAuthenticationServlet.java:53)
        at org.wso2.carbon.identity.application.authentication.framework.servlet.CommonAuthenticationServlet.doGet(CommonAuthenticationServlet.java:43)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:624)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:731)
        at org.eclipse.equinox.http.helper.ContextPathServletAdaptor.service(ContextPathServletAdaptor.java:37)
        at org.eclipse.equinox.http.servlet.internal.ServletRegistration.service(ServletRegistration.java:61)
        at org.eclipse.equinox.http.servlet.internal.ProxyServlet.processAlias(ProxyServlet.java:128)
        at org.eclipse.equinox.http.servlet.internal.ProxyServlet.service(ProxyServlet.java:60)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:731)
        at org.wso2.carbon.tomcat.ext.servlet.DelegationServlet.service(DelegationServlet.java:68)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:303)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
        at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
        at org.wso2.carbon.identity.captcha.filter.CaptchaFilter.doFilter(CaptchaFilter.java:76)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
        at org.owasp.csrfguard.CsrfGuardFilter.doFilter(CsrfGuardFilter.java:72)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
        at org.wso2.carbon.tomcat.ext.filter.CharacterSetFilter.doFilter(CharacterSetFilter.java:65)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
        at org.apache.catalina.filters.HttpHeaderSecurityFilter.doFilter(HttpHeaderSecurityFilter.java:124)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
        at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:219)
        at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:110)
        at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:169)
        at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:103)
        at org.wso2.carbon.identity.context.rewrite.valve.TenantContextRewriteValve.invoke(TenantContextRewriteValve.java:80)
        at org.wso2.carbon.identity.authz.valve.AuthorizationValve.invoke(AuthorizationValve.java:91)
        at org.wso2.carbon.identity.auth.valve.AuthenticationValve.invoke(AuthenticationValve.java:60)
        at org.wso2.carbon.tomcat.ext.valves.CompositeValve.continueInvocation(CompositeValve.java:99)
        at org.wso2.carbon.tomcat.ext.valves.CarbonTomcatValve$1.invoke(CarbonTomcatValve.java:47)
        at org.wso2.carbon.webapp.mgt.TenantLazyLoaderValve.invoke(TenantLazyLoaderValve.java:57)
        at org.wso2.carbon.tomcat.ext.valves.TomcatValveContainer.invokeValves(TomcatValveContainer.java:47)
        at org.wso2.carbon.tomcat.ext.valves.CompositeValve.invoke(CompositeValve.java:62)
        at org.wso2.carbon.tomcat.ext.valves.CarbonStuckThreadDetectionValve.invoke(CarbonStuckThreadDetectionValve.java:159)
        at org.apache.catalina.valves.AccessLogValve.invoke(AccessLogValve.java:962)
        at org.wso2.carbon.tomcat.ext.valves.CarbonContextCreatorValve.invoke(CarbonContextCreatorValve.java:57)
        at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:116)
        at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:445)
        at org.apache.coyote.http11.AbstractHttp11Processor.process(AbstractHttp11Processor.java:1115)
        at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:637)
        at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1775)
        at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.run(NioEndpoint.java:1734)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
```

This change avoids the NPE and allows to proceed with the authentication.

### When should this PR be merged
immediately

### Follow up actions
not required, functionality remains unchanged