### PR TITLE
Add ability to use default claim dialect for OIDC authenticators

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
@@ -41,6 +41,7 @@ public class OIDCAuthenticatorConstants {
     public static final String IS_BASIC_AUTH_ENABLED = "IsBasicAuthEnabled";
 
     public static final String OIDC_QUERY_PARAM_MAP_PROPERTY_KEY = "oidc:param.map";
+    public static final String OIDC_CLAIM_DIALECT = "http://wso2.org/oidc/claim";
 
     public class AuthenticatorConfParams {
         private AuthenticatorConfParams() {

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -39,6 +39,7 @@ import org.apache.oltu.oauth2.common.utils.JSONUtils;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.identity.application.authentication.framework.AbstractApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.FederatedApplicationAuthenticator;
+import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
@@ -46,6 +47,8 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authenticator.oidc.internal.OpenIDConnectAuthenticatorDataHolder;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
+import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
@@ -649,13 +652,30 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         return "http://wso2.org/oidc/claim";
     }
 
+    @Override
+    public String getClaimDialectURI(AuthenticationContext context) {
+
+        if (isNotUsingOIDCClaimDialect()) {
+            return getClaimDialectURI();
+        }
+
+        if (useOIDCClaimDialectDisabled(context)) {
+            // By returning null the default dialect will be used.
+            return null;
+        }
+
+        // If none of the above conditions satisfies we should follow the existing behaviour
+        // which was to return the OIDC claim dialect.
+        return getClaimDialectURI();
+    }
+
     /**
      * @subject
      */
     protected String getSubjectFromUserIDClaimURI(AuthenticationContext context) {
         String subject = null;
         try {
-            subject = FrameworkUtils.getFederatedSubjectFromClaims(context, getClaimDialectURI());
+            subject = FrameworkUtils.getFederatedSubjectFromClaims(context, getClaimDialectURI(context));
         } catch (Exception e) {
             if(log.isDebugEnabled()) {
                 log.debug("Couldn't find the subject claim from claim mappings ", e);
@@ -818,6 +838,74 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         }
 
         return null;
+    }
+
+    /**
+     * Check whether the getClaimDialectURI() method has been overwritten to not use the OIDC claim dialect.
+     */
+    private boolean isNotUsingOIDCClaimDialect() {
+
+        return !OIDCAuthenticatorConstants.OIDC_CLAIM_DIALECT.equals(getClaimDialectURI());
+    }
+
+    private boolean useOIDCClaimDialectDisabled(AuthenticationContext context) {
+
+        String useOIDCClaimDialect = getAuthenticatorPropertyFromAuthContext(context,
+                IdentityApplicationConstants.Authenticator.OIDC.USE_OIDC_CLAIM_DIALECT);
+
+        // Check if property has been disabled from the UI.
+        if (useOIDCClaimDialect != null) {
+            return !Boolean.valueOf(useOIDCClaimDialect);
+        }
+
+        // If UI property is not available check if property has been disabled from file config.
+        useOIDCClaimDialect = getAuthenticatorPropertyFromFileConfig(
+                IdentityApplicationConstants.Authenticator.OIDC.USE_OIDC_CLAIM_DIALECT);
+
+        if (StringUtils.isNotBlank(useOIDCClaimDialect)) {
+            return !Boolean.valueOf(useOIDCClaimDialect);
+        }
+
+        return false;
+    }
+
+    private String getAuthenticatorPropertyFromAuthContext(AuthenticationContext context, String propName) {
+
+        String propValue = null;
+
+        if (context.getExternalIdP().getIdentityProvider() != null) {
+            FederatedAuthenticatorConfig[] fedConfigs = context.getExternalIdP().getIdentityProvider()
+                    .getFederatedAuthenticatorConfigs();
+            if (fedConfigs != null) {
+                for (FederatedAuthenticatorConfig fedConfig : fedConfigs) {
+                    if (getName().equals(fedConfig.getName()) && fedConfig.getProperties() != null) {
+                        Property[] props = fedConfig.getProperties();
+                        for (Property prop : props) {
+                            if (propName.equals(prop.getName())) {
+                                propValue = prop.getValue();
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return propValue;
+    }
+
+    private String getAuthenticatorPropertyFromFileConfig(String propName) {
+
+        String propValue = null;
+
+        if (FileBasedConfigurationBuilder.getInstance()
+                .getAuthenticatorBean(OIDCAuthenticatorConstants.AUTHENTICATOR_NAME) != null) {
+            propValue = FileBasedConfigurationBuilder.getInstance()
+                    .getAuthenticatorBean(OIDCAuthenticatorConstants.AUTHENTICATOR_NAME).getParameterMap()
+                    .get(propName);
+        }
+
+        return propValue;
     }
 }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -46,6 +46,9 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authenticator.oidc.internal.OpenIDConnectAuthenticatorDataHolder;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.application.common.model.FederatedAuthenticatorConfig;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
@@ -466,14 +469,17 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
     }
 
     @Test
-    public void testGetSubjectFromUserIDClaimURI() throws FrameworkException {
+    public void testGetSubjectFromUserIDClaimURI() throws Exception {
         // Subject is null.
         assertNull(openIDConnectAuthenticator.getSubjectFromUserIDClaimURI(mockAuthenticationContext));
 
         // Subject is not null.
         mockStatic(FrameworkUtils.class);
+
+        when(mockAuthenticationContext.getExternalIdP()).thenReturn(externalIdPConfig);
+        when(externalIdPConfig.getIdentityProvider()).thenReturn(getDummyIdp());
         when(FrameworkUtils.getFederatedSubjectFromClaims(mockAuthenticationContext,
-                openIDConnectAuthenticator.getClaimDialectURI())).thenReturn("subject");
+                openIDConnectAuthenticator.getClaimDialectURI(mockAuthenticationContext))).thenReturn("subject");
         Assert.assertNotNull(openIDConnectAuthenticator.getSubjectFromUserIDClaimURI(mockAuthenticationContext));
     }
 
@@ -570,5 +576,24 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
         paramValueMap = new HashMap<>();
         when(mockAuthenticationContext.getProperty("oidc:param.map")).thenReturn(paramValueMap);
         when(mockAuthenticationContext.getContextIdentifier()).thenReturn("");
+    }
+
+    private IdentityProvider getDummyIdp() {
+
+        IdentityProvider identityProvider = new IdentityProvider();
+        FederatedAuthenticatorConfig[] authConfigs = new FederatedAuthenticatorConfig[1];
+        FederatedAuthenticatorConfig authConfig = new FederatedAuthenticatorConfig();
+        authConfig.setName(OIDCAuthenticatorConstants.AUTHENTICATOR_NAME);
+        Property[] props = new Property[1];
+        Property prop = new Property();
+        prop.setName(IdentityApplicationConstants.Authenticator.OIDC.USE_OIDC_CLAIM_DIALECT);
+        prop.setValue("true");
+        props[0] = prop;
+
+        authConfig.setProperties(props);
+        authConfigs[0] = authConfig;
+        identityProvider.setFederatedAuthenticatorConfigs(authConfigs);
+
+        return identityProvider;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -310,7 +310,7 @@
         <identity.application.auth.oidc.package.export.version>${project.version}
         </identity.application.auth.oidc.package.export.version>
 
-        <carbon.identity.framework.version>5.9.0</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.12.403</carbon.identity.framework.version>
         <oltu.version>1.0.0.wso2v3</oltu.version>
         <json-smart.version>2.3</json-smart.version>
         <json.wso2.version>3.0.0.wso2v1</json.wso2.version>


### PR DESCRIPTION
Partially solves https://github.com/wso2/product-is/issues/5437

Related to https://github.com/wso2/carbon-identity-framework/pull/2246

The PR implements code changes to support the usage of default claim dialect for OIDC authenticators. The code checks for UI property and if not available checks for a global config. If both configurations are not available it will call the earlier used getClaimDialectURI() method to keep the previous behaviour intact.  

It is possible to add the following configuration to the application-authentication.xml in `<AuthenticatorConfigs>` under  `<AuthenticatorConfig name="OpenIDConnectAuthenticator" enabled="true">` to set a global configuration to use the default claim dialect instead of the OIDC claim dialect for authenticators using the OIDC claim dialect.
```
<Parameter name="UseOIDCClaimDialect">false</Parameter>
```

Note: If some OpenIDConnectAuthenticator extending authenticator has overwritten the getClaimDialectURI() to send a different dialect these changes will still honour that and call that method.


### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
