### PR TITLE
Handle RP initiated OIDC federated logout

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
@@ -59,6 +59,7 @@ public class OIDCAuthenticatorConstants {
         public static final String CLIENT_SECRET = "ClientSecret";
         public static final String AUTHORIZATION_EP = "AuthorizationEndPoint";
         public static final String TOKEN_EP = "TokenEndPoint";
+        public static final String OIDC_LOGOUT_URL = "OIDCLogoutEPUrl";
         public static final String USER_INFO_EP = "UserInfoEndPoint";
     }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -41,6 +41,7 @@ import org.wso2.carbon.identity.application.authentication.framework.AbstractApp
 import org.wso2.carbon.identity.application.authentication.framework.FederatedApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
@@ -133,6 +134,12 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         }
         return callbackUrl;
     }
+
+    protected String getLogoutUrl(Map<String, String> authenticatorProperties) {
+
+        return authenticatorProperties.get(OIDCAuthenticatorConstants.IdPConfParams.OIDC_LOGOUT_URL);
+    }
+
 
     /**
      * Returns the token endpoint of OIDC federated authenticator
@@ -425,6 +432,19 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
 
         } catch (OAuthProblemException e) {
             throw new AuthenticationFailedException("Authentication process failed", context.getSubject(), e);
+        }
+    }
+
+    @Override
+    protected void initiateLogoutRequest(HttpServletRequest request, HttpServletResponse response, AuthenticationContext context) throws LogoutFailedException {
+
+        try {
+            String logoutUrl = getLogoutUrl(context.getAuthenticatorProperties());
+            if (StringUtils.isNotEmpty(logoutUrl)) {
+                response.sendRedirect(logoutUrl);
+            }
+        } catch (IOException e) {
+            throw new LogoutFailedException("Error occurred while initiating the logout request");
         }
     }
 


### PR DESCRIPTION
With the changes done in wso2/carbon-identity-framework#xxxx
the logout url added by the user is extracted and used at initiating the logout request.

Fixes: wso2/product-is#5958