### PR TITLE
Validate for code parameter in the request for canHandle method.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -120,7 +120,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         }
 
         String code = request.getParameter(OIDCAuthenticatorConstants.OAUTH2_GRANT_TYPE_CODE);
-        if (code != null && OIDCAuthenticatorConstants.LOGIN_TYPE.equals(getLoginType(request))) {
+        if (StringUtils.isNotBlank(code) && OIDCAuthenticatorConstants.LOGIN_TYPE.equals(getLoginType(request))) {
             return true;
         }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -118,7 +118,9 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         if (log.isTraceEnabled()) {
             log.trace("Inside OpenIDConnectAuthenticator.canHandle()");
         }
-        if (OIDCAuthenticatorConstants.LOGIN_TYPE.equals(getLoginType(request))) {
+
+        String code = request.getParameter(OIDCAuthenticatorConstants.OAUTH2_GRANT_TYPE_CODE);
+        if (code != null && OIDCAuthenticatorConstants.LOGIN_TYPE.equals(getLoginType(request))) {
             return true;
         }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -201,8 +201,13 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
         return new String[][]{
                 // When all parameters not null.
                 {"openid", "active,OIDC", "BASIC", "Error Login.", "true", "active", "Invalid can handle response for the request.", "Invalid context identifier."},
-                // When gran_type and login_type are null.
-                {null, "active,OIDC", null, "Error Login.", "true", "active", "Invalid can handle response for the request.", "Invalid context identifier."},
+                // When grant_type is null.
+                {null, "active,OIDC", "BASIC", "Error Login.", "false", "active", "Invalid can handle response for the request.", "Invalid context identifier."},
+                // When login_type is null.
+                {"openid", "active,OIDC", null, "Error Login.", "true", "active", "Invalid can handle response for " +
+                        "the request.", "Invalid context identifier."},
+                // When grant_type and login_type are null.
+                {null, "active,OIDC", null, "Error Login.", "false", "active", "Invalid can handle response for the " + "request.", "Invalid context identifier."},
                 // When all parameters null.
                 {null, null, null, null, "false", null, "Invalid can handle response for the request.", "Invalid context identifier."}
         };

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -200,16 +200,20 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
 
         return new String[][]{
                 // When all parameters not null.
-                {"openid", "active,OIDC", "BASIC", "Error Login.", "true", "active", "Invalid can handle response for the request.", "Invalid context identifier."},
+                {"openid", "active,OIDC", "BASIC", "Error Login.", "true", "active", "Invalid can handle response for" +
+                        " the request.", "Invalid context identifier."},
                 // When grant_type is null.
-                {null, "active,OIDC", "BASIC", "Error Login.", "false", "active", "Invalid can handle response for the request.", "Invalid context identifier."},
+                {null, "active,OIDC", "BASIC", "Error Login.", "false", "active", "Invalid can handle response for " +
+                        "the request.", "Invalid context identifier."},
                 // When login_type is null.
                 {"openid", "active,OIDC", null, "Error Login.", "true", "active", "Invalid can handle response for " +
                         "the request.", "Invalid context identifier."},
                 // When grant_type and login_type are null.
-                {null, "active,OIDC", null, "Error Login.", "false", "active", "Invalid can handle response for the " + "request.", "Invalid context identifier."},
+                {null, "active,OIDC", null, "Error Login.", "false", "active", "Invalid can handle response for the " +
+                        "request.", "Invalid context identifier."},
                 // When all parameters null.
-                {null, null, null, null, "false", null, "Invalid can handle response for the request.", "Invalid context identifier."}
+                {null, null, null, null, "false", null, "Invalid can handle response for the request.", "Invalid " +
+                        "context identifier."}
         };
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request

In the OIDC Authenticator, the canHandle() returns true whenever the state parameter for the request satisfy the loginType condition.
This fails in a scenario as described https://github.com/wso2/product-is/issues/10057, where there are more than one redirections before the user is prompted for authentication and an authorization code is returned. In such scenarios as per the current behaviour, the OIDC Authenticator would call the processAuthenticationResponse, even if no code parameter is returned in the request.

Resolves https://github.com/wso2/product-is/issues/10057.
