### PR TITLE
Update project-version to 5.6.x

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/pom.xml
@@ -20,7 +20,7 @@
         <groupId>org.wso2.carbon.identity.outbound.auth.oidc</groupId>
         <artifactId>identity-application-auth-oidc</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.5.10-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.application.authenticator.oidc.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.application.authenticator.oidc.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.outbound.auth.oidc</groupId>
         <artifactId>identity-application-auth-oidc</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.5.10-SNAPSHOT</version>
+        <version>5.6.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>org.wso2.carbon.identity.outbound.auth.oidc</groupId>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>identity-application-auth-oidc</artifactId>
-    <version>5.5.10-SNAPSHOT</version>
+    <version>5.6.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - OpenID Connect Application Authenticator Feature Aggregator Module</name>
     <description>


### PR DESCRIPTION
### Proposed changes in this pull request

Bump the project version to 5.6.x. The reason being the IS-5.10 version is compatible with the connector version 5.5.2. 

From 5.5.3 and onwards, the connector is compatible only with IS-5.11. For clarity, we can update the project version to 5.6.x and denote that v5.6.0 and onwards would be compatible with IS-5.11.
