### PR TITLE
Remove URL encoding for dynamic query parameters to avoid double encoding

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -1092,11 +1092,6 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
             if (values != null && values.length > 0) {
                 value = values[0];
             }
-            try {
-                value = URLEncoder.encode(value, StandardCharsets.UTF_8.name());
-            } catch (UnsupportedEncodingException e) {
-                log.error("Error while encoding the query param: " + name + " with value: " + value, e);
-            }
             if (log.isDebugEnabled()) {
                 log.debug("InterpretQueryString name: " + name + ", value: " + value);
             }


### PR DESCRIPTION
### Proposed changes in this pull request

Remove URL encoding for dynamic query parameters as it is done later in the code when encoding all the parameters at [1] (when encoding both - dynamic parameters sent via the inbound request, and static parameters added via federated IdP configuration).

[1] https://github.com/wso2-extensions/identity-outbound-auth-oidc/blob/88c1a20a735264f73abab6c14615d11f536ff9df/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java#L1125

Resolves : https://github.com/wso2/product-is/issues/11430



