### PR TITLE
Change JIT provisioned Managed profile name

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
@@ -28,6 +28,7 @@ public class OIDCAuthenticatorConstants {
 
     public static final String AUTHENTICATOR_NAME = "OpenIDConnectAuthenticator";
     public static final String LOGIN_TYPE = "OIDC";
+    public static final String AUTHENTICATOR_FRIENDLY_NAME = "OpenID Connect";
 
     public static final String OAUTH_OIDC_SCOPE = "openid";
     public static final String OAUTH2_GRANT_TYPE_CODE = "code";

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -860,7 +860,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
     @Override
     public String getFriendlyName() {
 
-        return "openidconnect";
+        return OIDCAuthenticatorConstants.AUTHENTICATOR_FRIENDLY_NAME;
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -508,7 +508,7 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
     @Test
     public void testGetFriendlyName() throws Exception {
 
-        assertEquals(openIDConnectAuthenticator.getFriendlyName(), "openidconnect",
+        assertEquals(openIDConnectAuthenticator.getFriendlyName(), "OpenID Connect",
                 "Invalid friendly name.");
     }
 


### PR DESCRIPTION
Related wso2-enterprise/asgardeo-product#5963

Change the `AUTHENTICATOR_FRIENDLY_NAME` constant of openIdConnect Authenticator as the `OpenID Connect`.