### PR TITLE
JDK 11 and 17 compatibility upgraded

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -1,7 +1,7 @@
 # This workflow will build the project on pull requests with tests
 # Uses:
 #   OS: ubuntu-latest
-#   JDK: Adopt JDK 8
+#   JDK: Adopt JDK 11 and Adopt JDK 17
 
 name: PR Builder
 
@@ -16,13 +16,15 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        java-version: [ 11, 17 ]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Adopt JDK 8
+      - name: Set up Adopt JDK 11 and 17
         uses: actions/setup-java@v2
         with:
-          java-version: "8"
+          java-version: ${{ matrix.java-version }}
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # identity-outbound-auth-oidc
+
+## Building from the source
+
+If you want to build **identity-application-auth-oidc** from the source code:
+
+1. Install Java 11 (or Java 17)
+2. Install Apache Maven 3.x.x (https://maven.apache.org/download.cgi#)
+3. Get a clone or download the source from this repository (https://github.com/wso2-extensions/identity-outbound-auth-oidc)
+4. Run the Maven command ``mvn clean install`` from the ``identity-outbound-auth-oidc`` directory.

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/pom.xml
@@ -90,7 +90,12 @@
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -183,6 +188,19 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.plugin.version}</version>
                 <configuration>
+                    <argLine>
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                        --add-opens java.base/java.io=ALL-UNNAMED
+                        --add-opens java.base/java.nio.charset=ALL-UNNAMED
+                        --add-opens java.base/java.net=ALL-UNNAMED
+                        --add-opens java.base/java.util.stream=ALL-UNNAMED
+                        --add-opens java.base/java.util.regex=ALL-UNNAMED
+                        --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
+                        --add-opens java.base/sun.nio.fs=ALL-UNNAMED
+                        --add-opens java.base/sun.nio.cs=ALL-UNNAMED
+                        --add-opens java.base/sun.net.www.protocol.https=ALL-UNNAMED
+                    </argLine>
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
                     </suiteXmlFiles>

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/logout/idpinit/processor/FederatedIdpInitLogoutProcessorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/logout/idpinit/processor/FederatedIdpInitLogoutProcessorTest.java
@@ -30,7 +30,7 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.powermock.reflect.internal.WhiteboxImpl;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.ServerSessionManagementService;
@@ -89,7 +89,7 @@ import static org.wso2.carbon.identity.application.authenticator.oidc.util.OIDCE
         IdentityDatabaseUtil.class, FrameworkUtils.class, XMLInputFactory.class, DataSource.class,
         UserSessionManagementService.class, OpenIDConnectAuthenticatorDataHolder.class, IdentityTenantUtil.class,
         UserSessionStore.class, ServerSessionManagementService.class})
-@PowerMockIgnore("jdk.internal.reflect.*")
+@PowerMockIgnore({"jdk.internal.reflect.*"})
 @WithH2Database(files = {"dbscripts/h2.sql"})
 public class FederatedIdpInitLogoutProcessorTest extends PowerMockTestCase {
 
@@ -123,7 +123,7 @@ public class FederatedIdpInitLogoutProcessorTest extends PowerMockTestCase {
                     "EKgyYA0-FHSbFNRtk3-rN25biW3ivU5AWeo9W3dI6epcNSr4pCCvWBIKI-rk01J8kYyu2ZujecyD0yoz420lbZ2c_dMKFpCDH" +
                     "DdYjueK4tYE66jpAzvJEyPs37snH-6ok2YaoYjKudyfCdXni7Bg";
 
-    @BeforeTest
+    @BeforeMethod
     public void init() throws Exception {
 
         logoutProcessor = new FederatedIdpInitLogoutProcessor();

--- a/pom.xml
+++ b/pom.xml
@@ -145,14 +145,33 @@
             <dependency>
                 <groupId>org.powermock</groupId>
                 <artifactId>powermock-module-testng</artifactId>
+                <version>${powermock.version}</version>
                 <scope>test</scope>
-                <version>${mokito.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-mockito</artifactId>
+                <artifactId>powermock-module-testng-common</artifactId>
+                <version>${powermock.version}</version>
                 <scope>test</scope>
-                <version>${mokito.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-api-mockito2</artifactId>
+                <version>${powermock.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/org.powermock/powermock-core -->
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-core</artifactId>
+                <version>${powermock.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.felix</groupId>
@@ -281,10 +300,11 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
         <org.slf4j.verison>1.6.1</org.slf4j.verison>
-        <testng.version>6.9.10</testng.version>
-        <jacoco.version>0.7.9</jacoco.version>
-        <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
-        <mokito.version>1.6.6</mokito.version>
+        <testng.version>7.0.0</testng.version>
+        <jacoco.version>0.8.4</jacoco.version>
+        <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
+        <mockito.version>3.10.0</mockito.version>
+        <powermock.version>2.0.2</powermock.version>
         <carbon.identity.oauth.common.version>6.2.0</carbon.identity.oauth.common.version>
         <carbon.identity.oauth.version>6.4.158</carbon.identity.oauth.version>
 


### PR DESCRIPTION
Purpose
Update the repository from mockito 1 to mockito 2 to support JDK 11 and JDK 17 compilation.

When should this PR be merged
After this PR is merged to the main branch, we can't build the branch on JDK 8

Related Issue
https://github.com/wso2/product-is/issues/14224