### PR TITLE
Set OIDC scopes as a primary field in OpenIdConnectAuthenticator Configuration

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
@@ -35,7 +35,6 @@ public class OIDCAuthenticatorConstants {
     public static final String OAUTH2_PARAM_STATE = "state";
     public static final String OAUTH2_ERROR = "error";
     public static final String REDIRECT_URI = "redirect_uri";
-    public static final String SCOPES = "scopes";
 
     public static final String ACCESS_TOKEN = "access_token";
     public static final String ID_TOKEN = "id_token";
@@ -45,6 +44,7 @@ public class OIDCAuthenticatorConstants {
     public static final String OAUTH2_AUTHZ_URL = "OAuth2AuthzEPUrl";
     public static final String OAUTH2_TOKEN_URL = "OAuth2TokenEPUrl";
     public static final String IS_BASIC_AUTH_ENABLED = "IsBasicAuthEnabled";
+    public static final String SCOPES = "Scopes";
 
     public static final String OIDC_QUERY_PARAM_MAP_PROPERTY_KEY = "oidc:param.map";
 

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
@@ -35,7 +35,6 @@ public class OIDCAuthenticatorConstants {
     public static final String OAUTH2_PARAM_STATE = "state";
     public static final String OAUTH2_ERROR = "error";
     public static final String REDIRECT_URI = "redirect_uri";
-    public static final String SCOPES = "scopes";
 
     public static final String ACCESS_TOKEN = "access_token";
     public static final String ID_TOKEN = "id_token";

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2015, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
@@ -35,6 +35,7 @@ public class OIDCAuthenticatorConstants {
     public static final String OAUTH2_PARAM_STATE = "state";
     public static final String OAUTH2_ERROR = "error";
     public static final String REDIRECT_URI = "redirect_uri";
+    public static final String SCOPES = "scopes";
 
     public static final String ACCESS_TOKEN = "access_token";
     public static final String ID_TOKEN = "id_token";

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
@@ -44,7 +44,6 @@ public class OIDCAuthenticatorConstants {
     public static final String OAUTH2_AUTHZ_URL = "OAuth2AuthzEPUrl";
     public static final String OAUTH2_TOKEN_URL = "OAuth2TokenEPUrl";
     public static final String IS_BASIC_AUTH_ENABLED = "IsBasicAuthEnabled";
-    public static final String SCOPES = "Scopes";
 
     public static final String OIDC_QUERY_PARAM_MAP_PROPERTY_KEY = "oidc:param.map";
 

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
@@ -1,17 +1,17 @@
-/*
- * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+/**
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -246,9 +246,9 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
     /**
      * @return
      */
-    protected String getOIDCScopes(Map<String, String> authenticatorProperties) {
+    protected String getScope(Map<String, String> authenticatorProperties) {
 
-        return authenticatorProperties.get("oidcScopes");
+        return authenticatorProperties.get(OIDCAuthenticatorConstants.SCOPES);
     }
 
     /**
@@ -362,7 +362,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
 
                 OAuthClientRequest authzRequest;
 
-                String oidcScopes = getOIDCScopes(authenticatorProperties);
+                String oidcScopes = getScope(authenticatorProperties);
 
                 String queryString = getQueryString(authenticatorProperties);
                 if (StringUtils.isNotBlank(oidcScopes)) {
@@ -370,7 +370,6 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                 }
                 queryString = interpretQueryString(context, queryString, request.getParameterMap());
                 Map<String, String> paramValueMap = new HashMap<>();
-
 
                 if (StringUtils.isNotBlank(queryString)) {
                     String[] params = queryString.split("&");
@@ -926,10 +925,10 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         configProperties.add(userIdLocation);
 
         Property scopes = new Property();
-        scopes.setName("oidcScopes");
+        scopes.setName(OIDCAuthenticatorConstants.SCOPES);
         scopes.setDisplayName("Scopes");
         scopes.setRequired(false);
-        scopes.setDescription("OIDC Scopes. e.g: profile email");
+        scopes.setDescription("OIDC Scopes.");
         scopes.setType("string");
         scopes.setDisplayOrder(8);
         configProperties.add(scopes);

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2013, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -1,17 +1,17 @@
-/*
- * Copyright (c) 2013, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+/**
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -918,7 +918,8 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         scopes.setName(OIDCAuthenticatorConstants.SCOPES);
         scopes.setDisplayName("Scopes");
         scopes.setRequired(false);
-        scopes.setDescription("OIDC Scopes.");
+        scopes.setDescription("List of scopes. Must be space-separated and at least include 'openid'");
+        scopes.setDefaultValue(OIDCAuthenticatorConstants.OAUTH_OIDC_SCOPE);
         scopes.setType("string");
         scopes.setDisplayOrder(8);
         configProperties.add(scopes);

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -233,10 +233,18 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
     }
 
     /**
-     * Get OIDC Scopes.
-     *
-     * @param authenticatorProperties Map<String, String> (Authenticator property, Property value)
-     * @return Scopes.
+     * @return
+     */
+    protected String getScope(String scope, Map<String, String> authenticatorProperties) {
+
+        if (StringUtils.isBlank(scope)) {
+            scope = OIDCAuthenticatorConstants.OAUTH_OIDC_SCOPE;
+        }
+        return scope;
+    }
+
+    /**
+     * @return
      */
     protected String getScope(Map<String, String> authenticatorProperties) {
 
@@ -354,11 +362,11 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
 
                 OAuthClientRequest authzRequest;
 
-                String scopes = getScope(authenticatorProperties);
+                String oidcScopes = getScope(authenticatorProperties);
 
                 String queryString = getQueryString(authenticatorProperties);
-                if (StringUtils.isNotBlank(scopes)) {
-                    queryString += "&scope=" + scopes;
+                if (StringUtils.isNotBlank(oidcScopes)) {
+                    queryString += "&scope=" + oidcScopes;
                 }
                 queryString = interpretQueryString(context, queryString, request.getParameterMap());
                 Map<String, String> paramValueMap = new HashMap<>();
@@ -374,6 +382,9 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                     context.setProperty(OIDCAuthenticatorConstants.OIDC_QUERY_PARAM_MAP_PROPERTY_KEY, paramValueMap);
                 }
                 queryString = getEvaluatedQueryString(paramValueMap);
+
+                String scope = paramValueMap.get(OAuthConstants.OAuth20Params.SCOPE);
+                scope = getScope(scope, authenticatorProperties);
 
                 if (StringUtils.isNotBlank(queryString) && queryString.toLowerCase().contains("scope=") && queryString
                         .toLowerCase().contains("redirect_uri=")) {
@@ -393,8 +404,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                 } else {
                     authzRequest = OAuthClientRequest.authorizationLocation(authorizationEP).setClientId(clientId)
                             .setRedirectURI(callbackurl)
-                            .setResponseType(OIDCAuthenticatorConstants.OAUTH2_GRANT_TYPE_CODE)
-                            .setScope(OIDCAuthenticatorConstants.OAUTH_OIDC_SCOPE)
+                            .setResponseType(OIDCAuthenticatorConstants.OAUTH2_GRANT_TYPE_CODE).setScope(scope)
                             .setState(state).buildQueryMessage();
                 }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -931,7 +931,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         scopes.setName(OIDCAuthenticatorConstants.SCOPES);
         scopes.setDisplayName("Scopes");
         scopes.setRequired(false);
-        scopes.setDescription("List of scopes. Must be space-separated and at least include 'openid'");
+        scopes.setDescription("A space-separated list of scopes. e.g: openid profile email");
         scopes.setDefaultValue(OIDCAuthenticatorConstants.OAUTH_OIDC_SCOPE);
         scopes.setType("string");
         scopes.setDisplayOrder(8);

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -235,20 +235,13 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
     /**
      * @return
      */
-    protected String getScope(String scope, Map<String, String> authenticatorProperties) {
+    protected String getScope(Map<String, String> authenticatorProperties) {
 
+        String scope = authenticatorProperties.get(OIDCAuthenticatorConstants.SCOPES);
         if (StringUtils.isBlank(scope)) {
             scope = OIDCAuthenticatorConstants.OAUTH_OIDC_SCOPE;
         }
         return scope;
-    }
-
-    /**
-     * @return
-     */
-    protected String getOIDCScopes(Map<String, String> authenticatorProperties) {
-
-        return authenticatorProperties.get("oidcScopes");
     }
 
     /**
@@ -362,15 +355,14 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
 
                 OAuthClientRequest authzRequest;
 
-                String oidcScopes = getOIDCScopes(authenticatorProperties);
+                String scope = getScope(authenticatorProperties);
 
                 String queryString = getQueryString(authenticatorProperties);
-                if (StringUtils.isNotBlank(oidcScopes)) {
-                    queryString += "&scope=" + oidcScopes;
+                if (StringUtils.isNotBlank(scope)) {
+                    queryString += "&scope=" + scope;
                 }
                 queryString = interpretQueryString(context, queryString, request.getParameterMap());
                 Map<String, String> paramValueMap = new HashMap<>();
-
 
                 if (StringUtils.isNotBlank(queryString)) {
                     String[] params = queryString.split("&");
@@ -383,9 +375,6 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                     context.setProperty(OIDCAuthenticatorConstants.OIDC_QUERY_PARAM_MAP_PROPERTY_KEY, paramValueMap);
                 }
                 queryString = getEvaluatedQueryString(paramValueMap);
-
-                String scope = paramValueMap.get(OAuthConstants.OAuth20Params.SCOPE);
-                scope = getScope(scope, authenticatorProperties);
 
                 if (StringUtils.isNotBlank(queryString) && queryString.toLowerCase().contains("scope=") && queryString
                         .toLowerCase().contains("redirect_uri=")) {
@@ -926,10 +915,10 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         configProperties.add(userIdLocation);
 
         Property scopes = new Property();
-        scopes.setName("oidcScopes");
+        scopes.setName(OIDCAuthenticatorConstants.SCOPES);
         scopes.setDisplayName("Scopes");
         scopes.setRequired(false);
-        scopes.setDescription("OIDC Scopes. e.g: profile email");
+        scopes.setDescription("OIDC Scopes.");
         scopes.setType("string");
         scopes.setDisplayOrder(8);
         configProperties.add(scopes);

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -233,18 +233,10 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
     }
 
     /**
-     * @return
-     */
-    protected String getScope(String scope, Map<String, String> authenticatorProperties) {
-
-        if (StringUtils.isBlank(scope)) {
-            scope = OIDCAuthenticatorConstants.OAUTH_OIDC_SCOPE;
-        }
-        return scope;
-    }
-
-    /**
-     * @return
+     * Get OIDC Scopes.
+     *
+     * @param authenticatorProperties Map<String, String> (Authenticator property, Property value)
+     * @return Scopes.
      */
     protected String getScope(Map<String, String> authenticatorProperties) {
 
@@ -362,11 +354,11 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
 
                 OAuthClientRequest authzRequest;
 
-                String oidcScopes = getScope(authenticatorProperties);
+                String scopes = getScope(authenticatorProperties);
 
                 String queryString = getQueryString(authenticatorProperties);
-                if (StringUtils.isNotBlank(oidcScopes)) {
-                    queryString += "&scope=" + oidcScopes;
+                if (StringUtils.isNotBlank(scopes)) {
+                    queryString += "&scope=" + scopes;
                 }
                 queryString = interpretQueryString(context, queryString, request.getParameterMap());
                 Map<String, String> paramValueMap = new HashMap<>();
@@ -382,9 +374,6 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                     context.setProperty(OIDCAuthenticatorConstants.OIDC_QUERY_PARAM_MAP_PROPERTY_KEY, paramValueMap);
                 }
                 queryString = getEvaluatedQueryString(paramValueMap);
-
-                String scope = paramValueMap.get(OAuthConstants.OAuth20Params.SCOPE);
-                scope = getScope(scope, authenticatorProperties);
 
                 if (StringUtils.isNotBlank(queryString) && queryString.toLowerCase().contains("scope=") && queryString
                         .toLowerCase().contains("redirect_uri=")) {
@@ -404,7 +393,8 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                 } else {
                     authzRequest = OAuthClientRequest.authorizationLocation(authorizationEP).setClientId(clientId)
                             .setRedirectURI(callbackurl)
-                            .setResponseType(OIDCAuthenticatorConstants.OAUTH2_GRANT_TYPE_CODE).setScope(scope)
+                            .setResponseType(OIDCAuthenticatorConstants.OAUTH2_GRANT_TYPE_CODE)
+                            .setScope(OIDCAuthenticatorConstants.OAUTH_OIDC_SCOPE)
                             .setState(state).buildQueryMessage();
                 }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -931,7 +931,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         scopes.setName(OIDCAuthenticatorConstants.SCOPES);
         scopes.setDisplayName("Scopes");
         scopes.setRequired(false);
-        scopes.setDescription("A space-separated list of scopes. e.g: openid profile email");
+        scopes.setDescription("A list of scopes");
         scopes.setDefaultValue(OIDCAuthenticatorConstants.OAUTH_OIDC_SCOPE);
         scopes.setType("string");
         scopes.setDisplayOrder(8);

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -938,7 +938,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         configProperties.add(scopes);
 
         Property additionalParams = new Property();
-        additionalParams.setName(IdentityApplicationConstants.Authenticator.QUERY_PARAMS);
+        additionalParams.setName(IdentityApplicationConstants.Authenticator.OIDC.QUERY_PARAMS);
         additionalParams.setDisplayName("Additional Query Parameters");
         additionalParams.setRequired(false);
         additionalParams.setDescription("Additional query parameters. e.g: paramName1=value1");

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -244,7 +244,10 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
     }
 
     /**
-     * @return
+     * Get Scopes.
+     *
+     * @param authenticatorProperties Map<String, String> (Authenticator property, Property value)
+     * @return Scopes.
      */
     protected String getScope(Map<String, String> authenticatorProperties) {
 
@@ -362,11 +365,11 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
 
                 OAuthClientRequest authzRequest;
 
-                String oidcScopes = getScope(authenticatorProperties);
+                String scopes = getScope(authenticatorProperties);
 
                 String queryString = getQueryString(authenticatorProperties);
-                if (StringUtils.isNotBlank(oidcScopes)) {
-                    queryString += "&scope=" + oidcScopes;
+                if (StringUtils.isNotBlank(scopes)) {
+                    queryString += "&scope=" + scopes;
                 }
                 queryString = interpretQueryString(context, queryString, request.getParameterMap());
                 Map<String, String> paramValueMap = new HashMap<>();

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -246,6 +246,14 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
     /**
      * @return
      */
+    protected String getOIDCScopes(Map<String, String> authenticatorProperties) {
+
+        return authenticatorProperties.get("oidcScopes");
+    }
+
+    /**
+     * @return
+     */
     protected boolean requiredIDToken(Map<String, String> authenticatorProperties) {
 
         return true;
@@ -354,9 +362,15 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
 
                 OAuthClientRequest authzRequest;
 
+                String oidcScopes = getOIDCScopes(authenticatorProperties);
+
                 String queryString = getQueryString(authenticatorProperties);
+                if (StringUtils.isNotBlank(oidcScopes)) {
+                    queryString += "&scope=" + oidcScopes;
+                }
                 queryString = interpretQueryString(context, queryString, request.getParameterMap());
                 Map<String, String> paramValueMap = new HashMap<>();
+
 
                 if (StringUtils.isNotBlank(queryString)) {
                     String[] params = queryString.split("&");
@@ -911,13 +925,22 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         userIdLocation.setDisplayOrder(7);
         configProperties.add(userIdLocation);
 
+        Property scopes = new Property();
+        scopes.setName("oidcScopes");
+        scopes.setDisplayName("Scopes");
+        scopes.setRequired(false);
+        scopes.setDescription("OIDC Scopes. e.g: profile email");
+        scopes.setType("string");
+        scopes.setDisplayOrder(8);
+        configProperties.add(scopes);
+
         Property additionalParams = new Property();
         additionalParams.setName("commonAuthQueryParams");
         additionalParams.setDisplayName("Additional Query Parameters");
         additionalParams.setRequired(false);
         additionalParams.setDescription("Additional query parameters. e.g: paramName1=value1");
         additionalParams.setType("string");
-        additionalParams.setDisplayOrder(8);
+        additionalParams.setDisplayOrder(9);
         configProperties.add(additionalParams);
 
         Property enableBasicAuth = new Property();
@@ -927,7 +950,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         enableBasicAuth.setDescription(
                 "Specifies that HTTP basic authentication should be used for client authentication, else client credentials will be included in the request body");
         enableBasicAuth.setType("boolean");
-        enableBasicAuth.setDisplayOrder(9);
+        enableBasicAuth.setDisplayOrder(10);
         configProperties.add(enableBasicAuth);
 
         return configProperties;

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -251,7 +251,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
      */
     protected String getScope(Map<String, String> authenticatorProperties) {
 
-        return authenticatorProperties.get(OIDCAuthenticatorConstants.SCOPES);
+        return authenticatorProperties.get(IdentityApplicationConstants.Authenticator.OIDC.SCOPES);
     }
 
     /**
@@ -928,7 +928,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         configProperties.add(userIdLocation);
 
         Property scopes = new Property();
-        scopes.setName(OIDCAuthenticatorConstants.SCOPES);
+        scopes.setName(IdentityApplicationConstants.Authenticator.OIDC.SCOPES);
         scopes.setDisplayName("Scopes");
         scopes.setRequired(false);
         scopes.setDescription("A list of scopes");
@@ -938,7 +938,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         configProperties.add(scopes);
 
         Property additionalParams = new Property();
-        additionalParams.setName("commonAuthQueryParams");
+        additionalParams.setName(IdentityApplicationConstants.Authenticator.QUERY_PARAMS);
         additionalParams.setDisplayName("Additional Query Parameters");
         additionalParams.setRequired(false);
         additionalParams.setDescription("Additional query parameters. e.g: paramName1=value1");

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -235,13 +235,20 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
     /**
      * @return
      */
-    protected String getScope(Map<String, String> authenticatorProperties) {
+    protected String getScope(String scope, Map<String, String> authenticatorProperties) {
 
-        String scope = authenticatorProperties.get(OIDCAuthenticatorConstants.SCOPES);
         if (StringUtils.isBlank(scope)) {
             scope = OIDCAuthenticatorConstants.OAUTH_OIDC_SCOPE;
         }
         return scope;
+    }
+
+    /**
+     * @return
+     */
+    protected String getOIDCScopes(Map<String, String> authenticatorProperties) {
+
+        return authenticatorProperties.get("oidcScopes");
     }
 
     /**
@@ -355,14 +362,15 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
 
                 OAuthClientRequest authzRequest;
 
-                String scope = getScope(authenticatorProperties);
+                String oidcScopes = getOIDCScopes(authenticatorProperties);
 
                 String queryString = getQueryString(authenticatorProperties);
-                if (StringUtils.isNotBlank(scope)) {
-                    queryString += "&scope=" + scope;
+                if (StringUtils.isNotBlank(oidcScopes)) {
+                    queryString += "&scope=" + oidcScopes;
                 }
                 queryString = interpretQueryString(context, queryString, request.getParameterMap());
                 Map<String, String> paramValueMap = new HashMap<>();
+
 
                 if (StringUtils.isNotBlank(queryString)) {
                     String[] params = queryString.split("&");
@@ -375,6 +383,9 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                     context.setProperty(OIDCAuthenticatorConstants.OIDC_QUERY_PARAM_MAP_PROPERTY_KEY, paramValueMap);
                 }
                 queryString = getEvaluatedQueryString(paramValueMap);
+
+                String scope = paramValueMap.get(OAuthConstants.OAuth20Params.SCOPE);
+                scope = getScope(scope, authenticatorProperties);
 
                 if (StringUtils.isNotBlank(queryString) && queryString.toLowerCase().contains("scope=") && queryString
                         .toLowerCase().contains("redirect_uri=")) {
@@ -915,10 +926,10 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         configProperties.add(userIdLocation);
 
         Property scopes = new Property();
-        scopes.setName(OIDCAuthenticatorConstants.SCOPES);
+        scopes.setName("oidcScopes");
         scopes.setDisplayName("Scopes");
         scopes.setRequired(false);
-        scopes.setDescription("OIDC Scopes.");
+        scopes.setDescription("OIDC Scopes. e.g: profile email");
         scopes.setType("string");
         scopes.setDisplayOrder(8);
         configProperties.add(scopes);

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -174,7 +174,7 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
         authenticatorProperties = new HashMap<>();
         authenticatorProperties.put("callbackUrl", "http://localhost:8080/playground2/oauth2client");
         authenticatorProperties.put("commonAuthQueryParams", "scope=openid&state=OIDC&loginType=basic");
-        authenticatorProperties.put("Scopes", "openid");
+        authenticatorProperties.put("Scopes", "openid email profile");
         authenticatorProperties.put("UserInfoUrl", "https://localhost:9443/oauth2/userinfo");
         authenticatorProperties.put(OIDCAuthenticatorConstants.CLIENT_ID, "u5FIfG5xzLvBGiamoAYzzcqpBqga");
         authenticatorProperties.put(OIDCAuthenticatorConstants.CLIENT_SECRET, "_kLtobqi08GytnypVW_Mmy1niAIa");
@@ -265,7 +265,7 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
     public void testGetScopePrimary() throws IOException {
 
         assertEquals(openIDConnectAuthenticator.getScope(authenticatorProperties),
-                "openid", "Unable to get the scope.");
+                "openid email profile", "Unable to get the scope.");
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -174,7 +174,6 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
         authenticatorProperties = new HashMap<>();
         authenticatorProperties.put("callbackUrl", "http://localhost:8080/playground2/oauth2client");
         authenticatorProperties.put("commonAuthQueryParams", "scope=openid&state=OIDC&loginType=basic");
-        authenticatorProperties.put("Scopes", "openid");
         authenticatorProperties.put("UserInfoUrl", "https://localhost:9443/oauth2/userinfo");
         authenticatorProperties.put(OIDCAuthenticatorConstants.CLIENT_ID, "u5FIfG5xzLvBGiamoAYzzcqpBqga");
         authenticatorProperties.put(OIDCAuthenticatorConstants.CLIENT_SECRET, "_kLtobqi08GytnypVW_Mmy1niAIa");
@@ -257,7 +256,7 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
     @Test
     public void testGetScope() throws IOException {
 
-        assertEquals(openIDConnectAuthenticator.getScope(authenticatorProperties),
+        assertEquals(openIDConnectAuthenticator.getScope("openid", authenticatorProperties),
                 "openid", "Unable to get the scope.");
     }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -173,8 +173,8 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
         openIDConnectAuthenticator = new OpenIDConnectAuthenticator();
         authenticatorProperties = new HashMap<>();
         authenticatorProperties.put("callbackUrl", "http://localhost:8080/playground2/oauth2client");
-        authenticatorProperties.put("commonAuthQueryParams", "scope=openid&state=OIDC&loginType=basic");
-        authenticatorProperties.put("Scopes", "openid email profile");
+        authenticatorProperties.put(IdentityApplicationConstants.Authenticator.QUERY_PARAMS, "scope=openid&state=OIDC&loginType=basic");
+        authenticatorProperties.put(IdentityApplicationConstants.Authenticator.OIDC.SCOPES, "openid email profile");
         authenticatorProperties.put("UserInfoUrl", "https://localhost:9443/oauth2/userinfo");
         authenticatorProperties.put(OIDCAuthenticatorConstants.CLIENT_ID, "u5FIfG5xzLvBGiamoAYzzcqpBqga");
         authenticatorProperties.put(OIDCAuthenticatorConstants.CLIENT_SECRET, "_kLtobqi08GytnypVW_Mmy1niAIa");

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -174,6 +174,7 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
         authenticatorProperties = new HashMap<>();
         authenticatorProperties.put("callbackUrl", "http://localhost:8080/playground2/oauth2client");
         authenticatorProperties.put("commonAuthQueryParams", "scope=openid&state=OIDC&loginType=basic");
+        authenticatorProperties.put("Scopes", "openid");
         authenticatorProperties.put("UserInfoUrl", "https://localhost:9443/oauth2/userinfo");
         authenticatorProperties.put(OIDCAuthenticatorConstants.CLIENT_ID, "u5FIfG5xzLvBGiamoAYzzcqpBqga");
         authenticatorProperties.put(OIDCAuthenticatorConstants.CLIENT_SECRET, "_kLtobqi08GytnypVW_Mmy1niAIa");
@@ -257,6 +258,13 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
     public void testGetScope() throws IOException {
 
         assertEquals(openIDConnectAuthenticator.getScope("openid", authenticatorProperties),
+                "openid", "Unable to get the scope.");
+    }
+
+    @Test
+    public void testGetScopePrimary() throws IOException {
+
+        assertEquals(openIDConnectAuthenticator.getScope(authenticatorProperties),
                 "openid", "Unable to get the scope.");
     }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -1,17 +1,17 @@
-/*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+/**
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -174,6 +174,7 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
         authenticatorProperties = new HashMap<>();
         authenticatorProperties.put("callbackUrl", "http://localhost:8080/playground2/oauth2client");
         authenticatorProperties.put("commonAuthQueryParams", "scope=openid&state=OIDC&loginType=basic");
+        authenticatorProperties.put("Scopes", "openid");
         authenticatorProperties.put("UserInfoUrl", "https://localhost:9443/oauth2/userinfo");
         authenticatorProperties.put(OIDCAuthenticatorConstants.CLIENT_ID, "u5FIfG5xzLvBGiamoAYzzcqpBqga");
         authenticatorProperties.put(OIDCAuthenticatorConstants.CLIENT_SECRET, "_kLtobqi08GytnypVW_Mmy1niAIa");
@@ -256,7 +257,7 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
     @Test
     public void testGetScope() throws IOException {
 
-        assertEquals(openIDConnectAuthenticator.getScope("openid", authenticatorProperties),
+        assertEquals(openIDConnectAuthenticator.getScope(authenticatorProperties),
                 "openid", "Unable to get the scope.");
     }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -173,7 +173,7 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
         openIDConnectAuthenticator = new OpenIDConnectAuthenticator();
         authenticatorProperties = new HashMap<>();
         authenticatorProperties.put("callbackUrl", "http://localhost:8080/playground2/oauth2client");
-        authenticatorProperties.put(IdentityApplicationConstants.Authenticator.QUERY_PARAMS, "scope=openid&state=OIDC&loginType=basic");
+        authenticatorProperties.put(IdentityApplicationConstants.Authenticator.OIDC.QUERY_PARAMS, "scope=openid&state=OIDC&loginType=basic");
         authenticatorProperties.put(IdentityApplicationConstants.Authenticator.OIDC.SCOPES, "openid email profile");
         authenticatorProperties.put("UserInfoUrl", "https://localhost:9443/oauth2/userinfo");
         authenticatorProperties.put(OIDCAuthenticatorConstants.CLIENT_ID, "u5FIfG5xzLvBGiamoAYzzcqpBqga");

--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
         <identity.application.auth.oidc.package.export.version>${project.version}
         </identity.application.auth.oidc.package.export.version>
 
-        <carbon.identity.framework.version>5.25.2</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.5</carbon.identity.framework.version>
         <oltu.version>1.0.0.wso2v3</oltu.version>
         <json-smart.version>2.4.7</json-smart.version>
         <json.wso2.version>3.0.0.wso2v1</json.wso2.version>


### PR DESCRIPTION
### Proposed changes in this pull request

For an OIDC external IdP, OIDC scope configuration controls which attributes are requested from the configured external IdP. In the on-prem IS, the default scope is set to openid. For setting additional scopes,  the Additional Query Parameters input field has to be used, where we can define the scope values as a space separated string. 
It is a requirement of the majority of application developers to get user attributes such as first name, email, etc. from an external IdP after authentication. Therefore configuring the scope in the IdP configuration becomes an important step.

This fix makes the scope a first class attribute by adding a separate field in the UI to add scope values.


Related issue: https://github.com/wso2/product-is/issues/14845
