### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
         <identity.application.auth.oidc.package.export.version>${project.version}
         </identity.application.auth.oidc.package.export.version>
 
-        <carbon.identity.framework.version>5.25.5</carbon.identity.framework.version>
+        <carbon.identity.framework.version>6.0.0</carbon.identity.framework.version>
         <oltu.version>1.0.0.wso2v3</oltu.version>
         <json-smart.version>2.4.7</json-smart.version>
         <json.wso2.version>3.0.0.wso2v1</json.wso2.version>
@@ -311,19 +311,19 @@
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
         <mockito.version>3.10.0</mockito.version>
         <powermock.version>2.0.2</powermock.version>
-        <carbon.identity.oauth.common.version>6.2.0</carbon.identity.oauth.common.version>
-        <carbon.identity.oauth.version>6.4.158</carbon.identity.oauth.version>
+        <carbon.identity.oauth.common.version>7.0.0</carbon.identity.oauth.common.version>
+        <carbon.identity.oauth.version>7.0.0</carbon.identity.oauth.version>
 
         <commons-lang.wso2.version>2.6.0.wso2v1</commons-lang.wso2.version>
         <commons-collections.wso2.version>3.2.2.wso2v1</commons-collections.wso2.version>
         <commons-codec.version>1.14.0.wso2v1</commons-codec.version>
 
-        <carbon.identity.inbound.oauth.package.import.version.range>[6.0.0, 7.0.0)
+        <carbon.identity.inbound.oauth.package.import.version.range>[7.0.0, 8.0.0)
         </carbon.identity.inbound.oauth.package.import.version.range>
-        <identity.framework.package.import.version.range>[5.14.0, 6.0.0)
+        <identity.framework.package.import.version.range>[6.0.0, 7.0.0)
         </identity.framework.package.import.version.range>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
-        <carbon.identity.oauth.common.package.import.version.range>[6.2.0, 7.0.0)
+        <carbon.identity.oauth.common.package.import.version.range>[7.0.0, 8.0.0)
         </carbon.identity.oauth.common.package.import.version.range>
         <carbon.kernel.package.import.version.range>[4.4.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <net.minidev.json.imp.pkg.version.range>[2.3.0, 3.0.0)</net.minidev.json.imp.pkg.version.range>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16