### PR TITLE
Enable PKCE in OIDC federated login flow

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
@@ -58,6 +58,9 @@ public class OIDCAuthenticatorConstants {
     public static final String LOGOUT_TOKEN = "logout_token";
     public static final Pattern OIDC_BACKCHANNEL_LOGOUT_ENDPOINT_URL_PATTERN = Pattern.compile("(.*)/identity/oidc" +
             "/slo(.*)");
+    
+    public static final String OAUTH_FEDERATED_PKCE_CODE_VERIFIER = "OAUTH_PKCE_CODE_VERIFIER";
+    public static final String ENABLE_FEDERATED_PKCE = "IsPKCEEnabled";
 
     public class AuthenticatorConfParams {
 

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
@@ -59,8 +59,8 @@ public class OIDCAuthenticatorConstants {
     public static final Pattern OIDC_BACKCHANNEL_LOGOUT_ENDPOINT_URL_PATTERN = Pattern.compile("(.*)/identity/oidc" +
             "/slo(.*)");
     
-    public static final String OAUTH_FEDERATED_PKCE_CODE_VERIFIER = "OAUTH_PKCE_CODE_VERIFIER";
-    public static final String ENABLE_FEDERATED_PKCE = "IsPKCEEnabled";
+    public static final String PKCE_CODE_VERIFIER = "PKCE_CODE_VERIFIER";
+    public static final String IS_PKCE_ENABLED = "IsPKCEEnabled";
 
     public class AuthenticatorConfParams {
 

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -98,10 +98,16 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
 
     private static final Log LOG = LogFactory.getLog(OpenIDConnectAuthenticator.class);
     private static final String OIDC_DIALECT = "http://wso2.org/oidc/claim";
+    private static final String PKCE_CODE_CHALLENGE_METHOD = "S256";
 
     private static final String DYNAMIC_PARAMETER_LOOKUP_REGEX = "\\$\\{(\\w+)\\}";
     private static Pattern pattern = Pattern.compile(DYNAMIC_PARAMETER_LOOKUP_REGEX);
     private static final String[] NON_USER_ATTRIBUTES = new String[]{"at_hash", "iss", "iat", "exp", "aud", "azp"};
+
+    private static final String IS_PKCE_ENABLED_NAME = "isPKCEEnabled";
+    private static final String IS_PKCE_ENABLED_DISPLAY_NAME = "Enable PKCE";
+    private static final String IS_PKCE_ENABLED_DESCRIPTION = "Specifies that PKCE should be used for client authentication";
+    private static final String TYPE_BOOLEAN = "boolean";
 
     @Override
     public AuthenticatorFlowStatus process(HttpServletRequest request, HttpServletResponse response,
@@ -375,7 +381,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                 String callbackurl = getCallbackUrl(authenticatorProperties);
                 String state = getStateParameter(context, authenticatorProperties);
                 boolean isPKCEEnabled = Boolean.parseBoolean(
-                        authenticatorProperties.get(OIDCAuthenticatorConstants.ENABLE_FEDERATED_PKCE));
+                        authenticatorProperties.get(OIDCAuthenticatorConstants.IS_PKCE_ENABLED));
 
                 OAuthClientRequest authzRequest;
 
@@ -435,13 +441,10 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                 // If PKCE is enabled, add code_challenge and code_challenge_method to the request.
                 if (isPKCEEnabled) {
                     String codeVerifier = generateCodeVerifier();
-                    context.setProperty(OIDCAuthenticatorConstants.OAUTH_FEDERATED_PKCE_CODE_VERIFIER, codeVerifier);
-                    try {
-                        String codeChallenge = generateCodeChallenge(codeVerifier);
-                        loginPage += "&code_challenge=" + codeChallenge + "&code_challenge_method=S256";
-                    } catch (NoSuchAlgorithmException e) {
-                        log.error("Error while generating the code challenge", e);
-                    }
+                    context.setProperty(OIDCAuthenticatorConstants.PKCE_CODE_VERIFIER, codeVerifier);
+                    String codeChallenge = generateCodeChallenge(codeVerifier);
+                    loginPage += "&code_challenge=" + codeChallenge + "&code_challenge_method="
+                            + PKCE_CODE_CHALLENGE_METHOD;
                 }
 
                 if (StringUtils.isNotBlank(queryString)) {
@@ -813,8 +816,8 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         String clientSecret = authenticatorProperties.get(OIDCAuthenticatorConstants.CLIENT_SECRET);
         String tokenEndPoint = getTokenEndpoint(authenticatorProperties);
         boolean isPKCEEnabled = Boolean.parseBoolean(
-                authenticatorProperties.get(OIDCAuthenticatorConstants.ENABLE_FEDERATED_PKCE));
-        Object codeVerifier = context.getProperty(OIDCAuthenticatorConstants.OAUTH_FEDERATED_PKCE_CODE_VERIFIER);
+                authenticatorProperties.get(OIDCAuthenticatorConstants.IS_PKCE_ENABLED));
+        String codeVerifier = (String) context.getProperty(OIDCAuthenticatorConstants.PKCE_CODE_VERIFIER);
 
         String callbackUrl = getCallbackUrlFromInitialRequestParamMap(context);
         if (StringUtils.isBlank(callbackUrl)) {
@@ -840,11 +843,10 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                         .setCode(authzResponse.getCode());
 
                 if (isPKCEEnabled) {
-                    if (codeVerifier != null) {
-                        tokenRequestBuilder.setParameter("code_verifier", codeVerifier.toString());
-                    } else {
-                        log.warn("PKCE is enabled, but the code verifier is not found.");
+                    if (StringUtils.isEmpty(codeVerifier)) {
+                        throw new AuthenticationFailedException("PKCE is enabled, but the code verifier is not found.");
                     }
+                    tokenRequestBuilder.setParameter("code_verifier", codeVerifier);
                 }
 
                 accessTokenRequest = tokenRequestBuilder.buildBodyMessage();
@@ -865,15 +867,14 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                         .setRedirectURI(callbackUrl)
                         .setCode(authzResponse.getCode());
                 if (isPKCEEnabled) {
-                    if (codeVerifier != null) {
-                        tokenRequestBuilder.setParameter("code_verifier", codeVerifier.toString());
-                    } else {
-                        log.warn("PKCE is enabled, but the code verifier is not found.");
+                    if (StringUtils.isEmpty(codeVerifier)) {
+                        throw new AuthenticationFailedException("PKCE is enabled, but the code verifier is not found.");
                     }
+                    tokenRequestBuilder.setParameter("code_verifier", codeVerifier);
                 }
                 accessTokenRequest = tokenRequestBuilder.buildBodyMessage();
             }
-            context.removeProperty(OIDCAuthenticatorConstants.OAUTH_FEDERATED_PKCE_CODE_VERIFIER);
+            context.removeProperty(OIDCAuthenticatorConstants.PKCE_CODE_VERIFIER);
             // set 'Origin' header to access token request.
             if (accessTokenRequest != null) {
                 // fetch the 'Hostname' configured in carbon.xml
@@ -1053,11 +1054,11 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         configProperties.add(enableBasicAuth);
 
         Property enablePKCE = new Property();
-        enablePKCE.setName("isPKCEEnabled");
-        enablePKCE.setDisplayName("Enable PKCE");
+        enablePKCE.setName(IS_PKCE_ENABLED_NAME);
+        enablePKCE.setDisplayName(IS_PKCE_ENABLED_DISPLAY_NAME);
         enablePKCE.setRequired(false);
-        enablePKCE.setDescription("Specifies that PKCE should be used for client authentication");
-        enablePKCE.setType("boolean");
+        enablePKCE.setDescription(IS_PKCE_ENABLED_DESCRIPTION);
+        enablePKCE.setType(TYPE_BOOLEAN);
         enablePKCE.setDisplayOrder(10);
         configProperties.add(enablePKCE);
 
@@ -1331,15 +1332,17 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
      *
      * @param codeVerifier code verifier
      * @return code challenge
-     * @throws UnsupportedEncodingException
-     * @throws NoSuchAlgorithmException
+     * @throws AuthenticationFailedException
      */
-    private String generateCodeChallenge(String codeVerifier)
-            throws UnsupportedEncodingException, NoSuchAlgorithmException {
-        byte[] bytes = codeVerifier.getBytes("US-ASCII");
-        MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
-        messageDigest.update(bytes, 0, bytes.length);
-        byte[] digest = messageDigest.digest();
-        return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
+    private String generateCodeChallenge(String codeVerifier) throws AuthenticationFailedException {
+        try {
+            byte[] bytes = codeVerifier.getBytes("US-ASCII");
+            MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
+            messageDigest.update(bytes, 0, bytes.length);
+            byte[] digest = messageDigest.digest();
+            return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
+        } catch (UnsupportedEncodingException | NoSuchAlgorithmException e) {
+            throw new AuthenticationFailedException("Error while generating code challenge", e);
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -72,6 +72,9 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -371,6 +374,8 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                 String authorizationEP = getOIDCAuthzEndpoint(authenticatorProperties);
                 String callbackurl = getCallbackUrl(authenticatorProperties);
                 String state = getStateParameter(context, authenticatorProperties);
+                boolean isPKCEEnabled = Boolean.parseBoolean(
+                        authenticatorProperties.get(OIDCAuthenticatorConstants.ENABLE_FEDERATED_PKCE));
 
                 OAuthClientRequest authzRequest;
 
@@ -425,6 +430,18 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
 
                 if (StringUtils.isNotBlank(domain)) {
                     loginPage = loginPage + "&fidp=" + domain;
+                }
+
+                // If PKCE is enabled, add code_challenge and code_challenge_method to the request.
+                if (isPKCEEnabled) {
+                    String codeVerifier = generateCodeVerifier();
+                    context.setProperty(OIDCAuthenticatorConstants.OAUTH_FEDERATED_PKCE_CODE_VERIFIER, codeVerifier);
+                    try {
+                        String codeChallenge = generateCodeChallenge(codeVerifier);
+                        loginPage += "&code_challenge=" + codeChallenge + "&code_challenge_method=S256";
+                    } catch (NoSuchAlgorithmException e) {
+                        log.error("Error while generating the code challenge", e);
+                    }
                 }
 
                 if (StringUtils.isNotBlank(queryString)) {
@@ -795,6 +812,9 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         String clientId = authenticatorProperties.get(OIDCAuthenticatorConstants.CLIENT_ID);
         String clientSecret = authenticatorProperties.get(OIDCAuthenticatorConstants.CLIENT_SECRET);
         String tokenEndPoint = getTokenEndpoint(authenticatorProperties);
+        boolean isPKCEEnabled = Boolean.parseBoolean(
+                authenticatorProperties.get(OIDCAuthenticatorConstants.ENABLE_FEDERATED_PKCE));
+        Object codeVerifier = context.getProperty(OIDCAuthenticatorConstants.OAUTH_FEDERATED_PKCE_CODE_VERIFIER);
 
         String callbackUrl = getCallbackUrlFromInitialRequestParamMap(context);
         if (StringUtils.isBlank(callbackUrl)) {
@@ -813,9 +833,21 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                             "authentication scheme.");
                 }
 
-                accessTokenRequest = OAuthClientRequest.tokenLocation(tokenEndPoint).setGrantType(GrantType
-                        .AUTHORIZATION_CODE).setRedirectURI(callbackUrl).setCode(authzResponse.getCode())
-                        .buildBodyMessage();
+                OAuthClientRequest.TokenRequestBuilder tokenRequestBuilder = OAuthClientRequest
+                        .tokenLocation(tokenEndPoint)
+                        .setGrantType(GrantType.AUTHORIZATION_CODE)
+                        .setRedirectURI(callbackUrl)
+                        .setCode(authzResponse.getCode());
+
+                if (isPKCEEnabled) {
+                    if (codeVerifier != null) {
+                        tokenRequestBuilder.setParameter("code_verifier", codeVerifier.toString());
+                    } else {
+                        log.warn("PKCE is enabled, but the code verifier is not found.");
+                    }
+                }
+
+                accessTokenRequest = tokenRequestBuilder.buildBodyMessage();
                 String base64EncodedCredential = new String(Base64.encodeBase64((clientId + ":" +
                         clientSecret).getBytes()));
                 accessTokenRequest.addHeader(OAuth.HeaderType.AUTHORIZATION, "Basic " + base64EncodedCredential);
@@ -825,10 +857,23 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                     LOG.debug("Authenticating to token endpoint: " + tokenEndPoint + " including client credentials "
                             + "in request body.");
                 }
-                accessTokenRequest = OAuthClientRequest.tokenLocation(tokenEndPoint).setGrantType(GrantType
-                        .AUTHORIZATION_CODE).setClientId(clientId).setClientSecret(clientSecret).setRedirectURI
-                        (callbackUrl).setCode(authzResponse.getCode()).buildBodyMessage();
+                OAuthClientRequest.TokenRequestBuilder tokenRequestBuilder = OAuthClientRequest
+                        .tokenLocation(tokenEndPoint)
+                        .setGrantType(GrantType.AUTHORIZATION_CODE)
+                        .setClientId(clientId)
+                        .setClientSecret(clientSecret)
+                        .setRedirectURI(callbackUrl)
+                        .setCode(authzResponse.getCode());
+                if (isPKCEEnabled) {
+                    if (codeVerifier != null) {
+                        tokenRequestBuilder.setParameter("code_verifier", codeVerifier.toString());
+                    } else {
+                        log.warn("PKCE is enabled, but the code verifier is not found.");
+                    }
+                }
+                accessTokenRequest = tokenRequestBuilder.buildBodyMessage();
             }
+            context.removeProperty(OIDCAuthenticatorConstants.OAUTH_FEDERATED_PKCE_CODE_VERIFIER);
             // set 'Origin' header to access token request.
             if (accessTokenRequest != null) {
                 // fetch the 'Hostname' configured in carbon.xml
@@ -844,7 +889,6 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         } catch (URLBuilderException e) {
             throw new RuntimeException("Error occurred while building URL in tenant qualified mode.", e);
         }
-
         return accessTokenRequest;
     }
 
@@ -1007,6 +1051,15 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         enableBasicAuth.setType("boolean");
         enableBasicAuth.setDisplayOrder(10);
         configProperties.add(enableBasicAuth);
+
+        Property enablePKCE = new Property();
+        enablePKCE.setName("isPKCEEnabled");
+        enablePKCE.setDisplayName("Enable PKCE");
+        enablePKCE.setRequired(false);
+        enablePKCE.setDescription("Specifies that PKCE should be used for client authentication");
+        enablePKCE.setType("boolean");
+        enablePKCE.setDisplayOrder(10);
+        configProperties.add(enablePKCE);
 
         return configProperties;
     }
@@ -1259,5 +1312,34 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         }
 
         return null;
+    }
+
+    /**
+     * Generate code verifier for PKCE
+     *
+     * @return code verifier
+     */
+    private String generateCodeVerifier() {
+        SecureRandom secureRandom = new SecureRandom();
+        byte[] codeVerifier = new byte[32];
+        secureRandom.nextBytes(codeVerifier);
+        return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(codeVerifier);
+    }
+
+    /**
+     * Generate code challenge for PKCE
+     *
+     * @param codeVerifier code verifier
+     * @return code challenge
+     * @throws UnsupportedEncodingException
+     * @throws NoSuchAlgorithmException
+     */
+    private String generateCodeChallenge(String codeVerifier)
+            throws UnsupportedEncodingException, NoSuchAlgorithmException {
+        byte[] bytes = codeVerifier.getBytes("US-ASCII");
+        MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
+        messageDigest.update(bytes, 0, bytes.length);
+        byte[] digest = messageDigest.digest();
+        return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -91,7 +91,6 @@ import static org.testng.Assert.assertTrue;
 @PrepareForTest({LogFactory.class, OAuthClient.class, URL.class, FrameworkUtils.class,
         OpenIDConnectAuthenticatorDataHolder.class, OAuthAuthzResponse.class, OAuthClientRequest.class,
         OAuthClientResponse.class, IdentityUtil.class, OpenIDConnectAuthenticator.class, ServiceURLBuilder.class})
-@PowerMockIgnore("jdk.internal.reflect.*")
 public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
 
     @Mock
@@ -397,6 +396,7 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
 
         setupTest();
         when(mockAuthenticationContext.getExternalIdP()).thenReturn(externalIdPConfig);
+        authenticatorProperties.put(OIDCAuthenticatorConstants.IS_PKCE_ENABLED, "false");
         when(openIDConnectAuthenticatorDataHolder.getClaimMetadataManagementService()).thenReturn
                 (claimMetadataManagementService);
         when(mockAuthenticationContext.getExternalIdP()).thenReturn(externalIdPConfig);
@@ -423,19 +423,17 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
     @Test()
     public void testGetAccessTokenRequestWithPKCE() throws URLBuilderException, AuthenticationFailedException {
         mockAuthenticationRequestContext(mockAuthenticationContext);
-        mockAuthenticationContext.getAuthenticatorProperties()
-                .put(OIDCAuthenticatorConstants.ENABLE_FEDERATED_PKCE, "true");
-        when(mockAuthenticationContext.getProperty(OIDCAuthenticatorConstants.OAUTH_FEDERATED_PKCE_CODE_VERIFIER))
+        authenticatorProperties.put(OIDCAuthenticatorConstants.IS_PKCE_ENABLED, "true");
+        when(mockAuthenticationContext.getProperty(OIDCAuthenticatorConstants.PKCE_CODE_VERIFIER))
                 .thenReturn("sample_code_verifier");
-        OAuthAuthzResponse oAuthAuthzResponse = mock(OAuthAuthzResponse.class);
-        when(oAuthAuthzResponse.getCode()).thenReturn("abc");
+        when(mockOAuthzResponse.getCode()).thenReturn("abc");
         mockStatic(ServiceURLBuilder.class);
         ServiceURLBuilder serviceURLBuilder = mock(ServiceURLBuilder.class);
         when(ServiceURLBuilder.create()).thenReturn(serviceURLBuilder);
         when(serviceURLBuilder.build()).thenReturn(serviceURL);
         when(serviceURL.getAbsolutePublicURL()).thenReturn("http://localhost:9443");
         OAuthClientRequest request = openIDConnectAuthenticator
-                .getAccessTokenRequest(mockAuthenticationContext, oAuthAuthzResponse);
+                .getAccessTokenRequest(mockAuthenticationContext, mockOAuthzResponse);
         assertTrue(request.getBody().contains("code_verifier=sample_code_verifier"));
     }
 
@@ -454,6 +452,7 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
 
         setupTest();
         authenticatorProperties.put("callbackUrl", " ");
+        authenticatorProperties.put(OIDCAuthenticatorConstants.IS_PKCE_ENABLED, "false");
         mockStatic(IdentityUtil.class);
         when(IdentityUtil.getServerURL(FrameworkConstants.COMMONAUTH, true, true)).thenReturn("http:/localhost:9443/oauth2/callback");
         setParametersForOAuthClientResponse(mockOAuthClientResponse, accessToken, idToken);
@@ -472,6 +471,7 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
 
         setupTest();
         authenticatorProperties.put("callbackUrl", "http://localhost:8080/playground2/oauth2client");
+        authenticatorProperties.put(OIDCAuthenticatorConstants.IS_PKCE_ENABLED, "false");
         Map<String, String> paramMap = new HashMap<>();
         paramMap.put("redirect_uri", "http:/localhost:9443/oauth2/redirect");
         when(mockAuthenticationContext.getProperty("oidc:param.map")).thenReturn(paramMap);


### PR DESCRIPTION
### Proposed changes in this pull request

This PR enables PKCE in OIDC federated login flow. In IDP configurations, a new checkbox has been introduced under Federated configurations to enable/disable PKCE in PR[1] and upon enabling the checkbox respective `code_verifier` and `code_challenge` parameters are added to the authentication and token requests.

Related to https://github.com/wso2/api-manager/issues/1613

[1] https://github.com/wso2/carbon-identity-framework/pull/4500