### PR TITLE
Add diagnostic logs to the authenticator

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/pom.xml
@@ -57,6 +57,10 @@
             <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
             <artifactId>org.wso2.carbon.identity.oauth.common</artifactId>
         </dependency>
@@ -123,6 +127,11 @@
             <version>${carbon.identity.framework.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -175,7 +184,9 @@
                             version="${carbon.identity.inbound.oauth.package.import.version.range}",
                             org.wso2.carbon.idp.mgt; version="${identity.framework.package.import.version.range}",
                             org.wso2.carbon.identity.application.common.util;
-                            version="${identity.framework.package.import.version.range}"
+                            version="${identity.framework.package.import.version.range}",
+                            org.wso2.carbon.identity.central.log.mgt.utils;
+                            version="${identity.framework.package.import.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.application.authenticator.oidc.internal,

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
@@ -149,7 +149,7 @@ public class OIDCAuthenticatorConstants {
         public static class ActionIDs {
 
             public static final String PROCESS_AUTHENTICATION_RESPONSE = "process-outbound-auth-oidc-response";
-            public static final String VALIDATE_OUTBOUND_AUTH_REQUEST = "validate-outbound-auth-oidc-request";
+            public static final String INITIATE_OUTBOUND_AUTH_REQUEST = "initiate-outbound-auth-oidc-request";
         }
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
@@ -135,4 +135,21 @@ public class OIDCAuthenticatorConstants {
 
         public static final long DEFAULT_IAT_VALIDITY_PERIOD = 15000;
     }
+
+    /**
+     * Constants related to log management.
+     */
+    public static class LogConstants {
+
+        public static final String OUTBOUND_AUTH_OIDC_SERVICE = "outbound-auth-oidc";
+
+        /**
+         * Define action IDs for diagnostic logs.
+         */
+        public static class ActionIDs {
+
+            public static final String PROCESS_AUTHENTICATION_RESPONSE = "process-outbound-auth-oidc-response";
+            public static final String VALIDATE_OUTBOUND_AUTH_REQUEST = "validate-outbound-auth-oidc-request";
+        }
+    }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -167,7 +167,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         boolean canHandle = OIDCAuthenticatorConstants.LOGIN_TYPE.equals(getLoginType(request));
         if (canHandle && LoggerUtils.isDiagnosticLogsEnabled()) {
             DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
-                    OUTBOUND_AUTH_OIDC_SERVICE, FrameworkConstants.LogConstants.ActionIDs.HANDLE_AUTH_STEP);
+                    getComponentId(), FrameworkConstants.LogConstants.ActionIDs.HANDLE_AUTH_STEP);
             diagnosticLogBuilder.resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
                     .logDetailLevel(DiagnosticLog.LogDetailLevel.INTERNAL_SYSTEM)
                     .resultMessage("Outbound OIDC authenticator handling the authentication.");
@@ -389,7 +389,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         try {
             if (LoggerUtils.isDiagnosticLogsEnabled()) {
                 DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
-                        OUTBOUND_AUTH_OIDC_SERVICE, VALIDATE_OUTBOUND_AUTH_REQUEST);
+                        getComponentId(), VALIDATE_OUTBOUND_AUTH_REQUEST);
                 diagnosticLogBuilder.resultMessage("Validate outbound oidc authentication request")
                         .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
                         .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
@@ -401,7 +401,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
             if (authenticatorProperties != null) {
                 DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = null;
                 if (LoggerUtils.isDiagnosticLogsEnabled()) {
-                    diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(OUTBOUND_AUTH_OIDC_SERVICE,
+                    diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(getComponentId(),
                             VALIDATE_OUTBOUND_AUTH_REQUEST);
                     diagnosticLogBuilder.logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
                             .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
@@ -535,7 +535,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
 
         if (LoggerUtils.isDiagnosticLogsEnabled()) {
             DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
-                    OUTBOUND_AUTH_OIDC_SERVICE, PROCESS_AUTHENTICATION_RESPONSE);
+                    getComponentId(), PROCESS_AUTHENTICATION_RESPONSE);
             diagnosticLogBuilder.resultMessage("Processing outbound oidc authentication response.")
                     .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
                     .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
@@ -568,7 +568,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = null;
         if (LoggerUtils.isDiagnosticLogsEnabled()) {
             diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
-                    OUTBOUND_AUTH_OIDC_SERVICE, PROCESS_AUTHENTICATION_RESPONSE);
+                    getComponentId(), PROCESS_AUTHENTICATION_RESPONSE);
             diagnosticLogBuilder.inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep())
                     .inputParams(getApplicationDetails(context))
                     .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION);
@@ -1257,6 +1257,15 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
             LOG.debug("response: " + builder.toString());
         }
         return builder.toString();
+    }
+
+    /**
+     * Return the component ID of the Authenticator. This will be used for logging purposes.
+     * @return Component ID String.
+     */
+    protected String getComponentId() {
+
+        return OUTBOUND_AUTH_OIDC_SERVICE;
     }
 
     private String interpretQueryString(AuthenticationContext context, String queryString,

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -400,6 +400,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                         .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
                         .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
                         .inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep())
+                        .inputParam(LogConstants.InputKeys.IDP, context.getExternalIdP().getIdPName())
                         .inputParams(getApplicationDetails(context));
                 LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
             }
@@ -413,6 +414,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                             .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
                             .inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep())
                             .inputParam("authenticator properties", authenticatorProperties.keySet())
+                            .inputParam(LogConstants.InputKeys.IDP, context.getExternalIdP().getIdPName())
                             .inputParams(getApplicationDetails(context));
                 }
                 String clientId = authenticatorProperties.get(OIDCAuthenticatorConstants.CLIENT_ID);
@@ -545,6 +547,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                     .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
                     .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
                     .inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep())
+                    .inputParam(LogConstants.InputKeys.IDP, context.getExternalIdP().getIdPName())
                     .inputParams(getApplicationDetails(context));
             LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
         }
@@ -576,6 +579,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                     getComponentId(), PROCESS_AUTHENTICATION_RESPONSE);
             diagnosticLogBuilder.inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep())
                     .inputParams(getApplicationDetails(context))
+                    .inputParam(LogConstants.InputKeys.IDP, context.getExternalIdP().getIdPName())
                     .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION);
         }
         if (StringUtils.isNotBlank(idToken)) {

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -640,7 +640,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         authenticatedUser.setUserAttributes(claimsMap);
         context.setSubject(authenticatedUser);
         if (LoggerUtils.isDiagnosticLogsEnabled() && diagnosticLogBuilder != null) {
-            diagnosticLogBuilder.resultMessage("Successfully completed the outbound OIDC authentication response.")
+            diagnosticLogBuilder.resultMessage("Outbound OIDC authentication response processed successfully.")
                     .resultStatus(DiagnosticLog.ResultStatus.SUCCESS);
             diagnosticLogBuilder.inputParam("user attributes (local claim : remote claim)",
                     getUserAttributeClaimMappingList(authenticatedUser));

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -48,6 +48,7 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.authenticator.oidc.internal.OpenIDConnectAuthenticatorDataHolder;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.core.ServiceURL;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
@@ -89,7 +90,7 @@ import static org.wso2.carbon.identity.application.authenticator.oidc.OIDCAuthen
  */
 @PrepareForTest({LogFactory.class, OAuthClient.class, URL.class, FrameworkUtils.class,
         OpenIDConnectAuthenticatorDataHolder.class, OAuthAuthzResponse.class, OAuthClientRequest.class,
-        OAuthClientResponse.class, IdentityUtil.class, OpenIDConnectAuthenticator.class, ServiceURLBuilder.class})
+        OAuthClientResponse.class, IdentityUtil.class, OpenIDConnectAuthenticator.class, ServiceURLBuilder.class, LoggerUtils.class})
 public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
 
     @Mock
@@ -218,6 +219,8 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
     @Test(dataProvider = "requestDataHandler")
     public void testCanHandle(String grantType, String state, String loginType, String error, String expectedCanHandler, String expectedContext, String msgCanHandler, String msgContext) throws IOException {
 
+        mockStatic(LoggerUtils.class);
+        when(LoggerUtils.isDiagnosticLogsEnabled()).thenReturn(true);
         when(mockServletRequest.getParameter(OIDCAuthenticatorConstants.OAUTH2_GRANT_TYPE_CODE)).thenReturn(grantType);
         when(mockServletRequest.getParameter(OIDCAuthenticatorConstants.OAUTH2_PARAM_STATE)).thenReturn(state);
         when(mockServletRequest.getParameter(OIDCAuthenticatorConstants.LOGIN_TYPE)).thenReturn(loginType);
@@ -386,6 +389,8 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
     public void testInitiateAuthenticationRequestNullProperties() throws OAuthSystemException,
             OAuthProblemException, AuthenticationFailedException, UserStoreException {
 
+        mockStatic(LoggerUtils.class);
+        when(LoggerUtils.isDiagnosticLogsEnabled()).thenReturn(true);
         mockAuthenticationRequestContext(mockAuthenticationContext);
         when(mockAuthenticationContext.getAuthenticatorProperties()).thenReturn(null);
         openIDConnectAuthenticator.initiateAuthenticationRequest(mockServletRequest, mockServletResponse,
@@ -454,6 +459,8 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
         authenticatorProperties.put("callbackUrl", " ");
         mockStatic(IdentityUtil.class);
         when(IdentityUtil.getServerURL(FrameworkConstants.COMMONAUTH, true, true)).thenReturn("http:/localhost:9443/oauth2/callback");
+        mockStatic(LoggerUtils.class);
+        when(LoggerUtils.isDiagnosticLogsEnabled()).thenReturn(true);
         setParametersForOAuthClientResponse(mockOAuthClientResponse, accessToken, idToken);
         when(openIDConnectAuthenticatorDataHolder.getClaimMetadataManagementService()).thenReturn
                 (claimMetadataManagementService);
@@ -484,6 +491,7 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
     public void testPassProcessAuthenticationWithParamValue() throws Exception {
 
         setupTest();
+        when(LoggerUtils.isDiagnosticLogsEnabled()).thenReturn(true);
         authenticatorProperties.put("callbackUrl", "http://localhost:8080/playground2/oauth2client");
         Map<String, String> paramMap = new HashMap<>();
         paramMap.put("redirect_uri", "http:/localhost:9443/oauth2/redirect");
@@ -677,6 +685,9 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
         when(serviceURLBuilder.addPath(anyString())).thenReturn(serviceURLBuilder);
         when(serviceURLBuilder.addParameter(anyString(), anyString())).thenReturn(serviceURLBuilder);
         when(serviceURLBuilder.build()).thenReturn(serviceURL);
+
+        mockStatic(LoggerUtils.class);
+        when(LoggerUtils.isDiagnosticLogsEnabled()).thenReturn(true);
     }
 
     private void setParametersForOAuthClientResponse(OAuthClientResponse mockOAuthClientResponse,

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -47,6 +47,7 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authenticator.oidc.internal.OpenIDConnectAuthenticatorDataHolder;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
@@ -665,6 +666,7 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
         when(mockOAuthzResponse.getCode()).thenReturn("200");
         when(mockAuthenticationContext.getProperty(OIDCAuthenticatorConstants.ACCESS_TOKEN)).thenReturn(accessToken);
         when(mockAuthenticationContext.getProperty(OIDCAuthenticatorConstants.ID_TOKEN)).thenReturn(idToken);
+        when(mockAuthenticationContext.getExternalIdP()).thenReturn(getDummyExternalIdPConfig());
         setParametersForOAuthClientResponse(mockOAuthClientResponse, accessToken, idToken);
         mockStatic(OpenIDConnectAuthenticatorDataHolder.class);
         when(OpenIDConnectAuthenticatorDataHolder.getInstance()).thenReturn(openIDConnectAuthenticatorDataHolder);
@@ -703,5 +705,13 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
         paramValueMap = new HashMap<>();
         when(mockAuthenticationContext.getProperty("oidc:param.map")).thenReturn(paramValueMap);
         when(mockAuthenticationContext.getContextIdentifier()).thenReturn("");
+        when(mockAuthenticationContext.getExternalIdP()).thenReturn(getDummyExternalIdPConfig());
+    }
+
+    private ExternalIdPConfig getDummyExternalIdPConfig() {
+
+        IdentityProvider identityProvider = new IdentityProvider();
+        identityProvider.setIdentityProviderName("DummyIDPName");
+        return new ExternalIdPConfig(identityProvider);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.testutil</artifactId>
                 <version>${carbon.identity.framework.version}</version>
                 <scope>test</scope>
@@ -196,6 +201,12 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+                <version>${identity.organization.management.core.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
                 <version>${h2database.version}</version>
@@ -293,11 +304,11 @@
         <identity.application.auth.oidc.package.export.version>${project.version}
         </identity.application.auth.oidc.package.export.version>
 
-        <carbon.identity.framework.version>5.25.90</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.260</carbon.identity.framework.version>
         <oltu.version>1.0.0.wso2v3</oltu.version>
         <json-smart.version>2.4.7</json-smart.version>
         <json.wso2.version>3.0.0.wso2v2</json.wso2.version>
-        <carbon.kernel.version>4.9.0</carbon.kernel.version>
+        <carbon.kernel.version>4.9.10</carbon.kernel.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
         <org.slf4j.verison>1.6.1</org.slf4j.verison>
@@ -308,6 +319,8 @@
         <powermock.version>2.0.2</powermock.version>
         <carbon.identity.oauth.common.version>6.2.0</carbon.identity.oauth.common.version>
         <carbon.identity.oauth.version>6.4.158</carbon.identity.oauth.version>
+
+        <identity.organization.management.core.version>1.0.50</identity.organization.management.core.version>
 
         <commons-lang.wso2.version>2.6.0.wso2v1</commons-lang.wso2.version>
         <commons-collections.wso2.version>3.2.2.wso2v1</commons-collections.wso2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -328,9 +328,9 @@
 
         <carbon.identity.inbound.oauth.package.import.version.range>[6.0.0, 7.0.0)
         </carbon.identity.inbound.oauth.package.import.version.range>
-        <identity.framework.package.import.version.range>[5.14.0, 7.0.0)
+        <identity.framework.package.import.version.range>[5.25.260, 7.0.0)
         </identity.framework.package.import.version.range>
-        <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
+        <carbon.kernel.package.import.version.range>[4.9.10, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.identity.oauth.common.package.import.version.range>[6.2.0, 7.0.0)
         </carbon.identity.oauth.common.package.import.version.range>
         <carbon.kernel.package.import.version.range>[4.4.0, 5.0.0)</carbon.kernel.package.import.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request
* Add diagnostic logs to the outbound OIDC authenticator


### Approach
![image](https://github.com/wso2-extensions/identity-outbound-auth-oidc/assets/32576163/361be690-b796-4a52-aac3-f4492bf7129b)


Diagnostic logs will be covered the green-colored actions/validations of the authentication process. 
1. Authentication Request Validation
Within each authenticator, the `initiateAuthenticationRequest` method houses the logic for this step. This triggers two diagnostic logs. The first log indicates the initialization of the authentication request, and the second log shows the authentication request has been successfully sent – whether it's a Success or marked Invalid.

2. Validate Authentication Response
The `processAuthenticationResponse` method handles authentication responses sent by the federated IDP. Once users are sent to the federated IDP page and complete the login, the authenticator receives an authentication response sent by the federated IDP, which this method manages. Just like the request validation, this step also generates two diagnostic logs. The first one marks the beginning of response validation, while the second one is only created if the authentication is successful. We've chosen not to include logs for authentication response failures for a couple of reasons:
- Numerous potential failure scenarios across authenticators make adding logs for each too complicated and code-heavy.
- With https://github.com/wso2/carbon-identity-framework/pull/4809, there's a common log in place that covers and reports authentication response failures caused by authenticators.

Additionally, there will be another diagnostic log that will get published from the canHandle() method of the authenticator. The `canHandle` method gets executed each time before the `initiateAuthenticationRequest` and `processAuthenticationResponse` get executed. This log is published as an internal log for our internal developers. The purpose of this log is to verify whether the auth request/response was passed into the authenticator to handle it.


I've also introduced a new protected method named getComponentId. This addition serves a specific purpose. The OpenIDAuthenticator class extends into other Authenticators like GitHub and Google. These extended Authenticators utilize the initiateAuthenticationRequest and processAuthenticationResponse methods from the OpenIDAuthenticator class. However, this can lead to diagnostic logs being attributed to the OIDC authenticator even when they're handled by the relevant Authenticator (with no change in the component ID of the logs).
To address this, I've implemented the getComponentId method. This method returns the component ID. When each Authenticator (like Google or Github) overrides this method, the component ID in the logs gets adjusted accordingly. This ensures that the logs correctly reflect the handling Authenticator.