### PR TITLE
Improve Exception Handling and Add Unit Tests for API based Authentication

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/util/OIDCErrorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/util/OIDCErrorConstants.java
@@ -40,6 +40,9 @@ public class OIDCErrorConstants {
                 "Cannot find the userId from the id_token sent by the federated IDP."),
         NONCE_MISMATCH("OID-60016", "The nonce claim of the ID token is not equal to the nonce value " +
                 "sent in the authentication request"),
+        INVALID_JWT_TOKEN("OID-60017", "JWT token is invalid."),
+        JWT_TOKEN_AUD_CLAIM_VALIDATION_FAILED("OID-60018",
+                "None of the audience values matched the token endpoint alias: %s."),
         // Federated IdP initiated back-channel logout client errors.
         LOGOUT_TOKEN_EMPTY_OR_NULL("OID-60006",
                 "Logout token is empty or null. Pass a valid logout token"),
@@ -93,10 +96,9 @@ public class OIDCErrorConstants {
         LOGOUT_SERVER_EXCEPTION("OID-65015", "Back channel logout failed due to server error"),
         JWT_TOKEN_ISS_CLAIM_VALIDATION_FAILED(
                 "OID-65016", "Error while validating the iss claim in the jwt token"),
-        JWT_TOKEN_SIGNATURE_VALIDATION_FAILED("OID-65016",
-                                                         "Error while validating the JWT token signature"),
-        JWT_TOKEN_AUD_CLAIM_VALIDATION_FAILED("OID-65017",
-                                                         "Audience claim validation failed.");
+        JWT_TOKEN_VALIDATION_FAILED("OID-65016", "JWT token validation Failed."),
+        JWT_TOKEN_SIGNATURE_VALIDATION_FAILED("OID-65017",
+                "Error while validating the JWT token signature");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/util/OIDCTokenValidationUtil.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/util/OIDCTokenValidationUtil.java
@@ -61,7 +61,9 @@ public class OIDCTokenValidationUtil {
      *
      * @param audienceList - list containing audience values.
      * @param idp - identity provider.
-     * @Param tenantDomain - the tenant domain
+     * @param tenantDomain - the tenant domain
+     *
+     * @throws AuthenticationFailedException if none of the audience values matched the tokenEndpoint alias
      */
     public static void validateAudience(List<String> audienceList, IdentityProvider idp, String tenantDomain)
             throws AuthenticationFailedException {
@@ -78,8 +80,10 @@ public class OIDCTokenValidationUtil {
             }
         }
         if (!audienceFound) {
-            throw new AuthenticationFailedException ("None of the audience values matched the tokenEndpoint Alias "
-                    + tokenEndPointAlias);
+            throw new AuthenticationFailedException (
+                    OIDCErrorConstants.ErrorMessages.JWT_TOKEN_AUD_CLAIM_VALIDATION_FAILED.getCode(),
+                    String.format(OIDCErrorConstants.ErrorMessages.JWT_TOKEN_AUD_CLAIM_VALIDATION_FAILED.getMessage(),
+                            tokenEndPointAlias));
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
         <identity.application.auth.oidc.package.export.version>${project.version}
         </identity.application.auth.oidc.package.export.version>
 
-        <carbon.identity.framework.version>5.25.484</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.491</carbon.identity.framework.version>
         <oltu.version>1.0.0.wso2v3</oltu.version>
         <json-smart.version>2.4.7</json-smart.version>
         <json.wso2.version>3.0.0.wso2v2</json.wso2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
         <identity.application.auth.oidc.package.export.version>${project.version}
         </identity.application.auth.oidc.package.export.version>
 
-        <carbon.identity.framework.version>5.25.431</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.484</carbon.identity.framework.version>
         <oltu.version>1.0.0.wso2v3</oltu.version>
         <json-smart.version>2.4.7</json-smart.version>
         <json.wso2.version>3.0.0.wso2v2</json.wso2.version>


### PR DESCRIPTION
### Proposed changes in this pull request

- Exceptions thrown by `validateJWTToken()` method are differentiated whether they are client or server exceptions and handheld accordingly.
- Avoid possible null pointer exception by swapping the values used in equal check inside `isTrustedTokenIssuer()` method.
- Add more unit tests into `OpenIDConnectAuthenticatorTest` and `OIDCTokenValidationUtilTest` classes in order to verify API based authentication functionality of the OIDC authenticator.
- Bump framework version.