### PR TITLE
Add callback resolver method

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -279,7 +279,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
     /**
      * Resolve the callback URL from the context properties to use in the API based authentication flow.
      *
-     * @param context                Authentication context.
+     * @param context Authentication context.
      * @return Callback URL to be used in API based authentication flow.
      */
     protected String resolveCallBackURLForAPIBasedAuthFlow(AuthenticationContext context) {

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -277,21 +277,14 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
     }
 
     /**
-     * Resolve the callback URL of the IdP, based on authenticator properties and the context properties
-     * to use in the API based authentication flow.
+     * Resolve the callback URL from the context properties to use in the API based authentication flow.
      *
-     * @param authenticatorProperties Authenticator properties.
      * @param context                Authentication context.
      * @return Callback URL to be used in API based authentication flow.
      */
-    protected String resolveCallBackURLForAPIBasedAuthFlow(Map<String, String> authenticatorProperties,
-                                                           AuthenticationContext context) {
+    protected String resolveCallBackURLForAPIBasedAuthFlow(AuthenticationContext context) {
 
-        String callbackurl = getCallbackUrl(authenticatorProperties);
-        if (Boolean.parseBoolean((String) context.getProperty(IS_API_BASED))) {
-            callbackurl = (String) context.getProperty(REDIRECT_URL);
-        }
-        return callbackurl;
+        return (String) context.getProperty(REDIRECT_URL);
     }
 
     protected String getLogoutUrl(Map<String, String> authenticatorProperties) {
@@ -474,8 +467,11 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                 }
                 String clientId = authenticatorProperties.get(OIDCAuthenticatorConstants.CLIENT_ID);
                 String authorizationEP = getOIDCAuthzEndpoint(authenticatorProperties);
-                String callbackurl = resolveCallBackURLForAPIBasedAuthFlow(authenticatorProperties, context);
+                String callbackurl = getCallbackUrl(authenticatorProperties);
 
+                if (Boolean.parseBoolean((String) context.getProperty(IS_API_BASED))) {
+                    callbackurl = resolveCallBackURLForAPIBasedAuthFlow(context);
+                }
                 String state = getStateParameter(request, context, authenticatorProperties);
                 context.setProperty(OIDCAuthenticatorConstants.AUTHENTICATOR_NAME + STATE_PARAM_SUFFIX, state);
                 String nonce = UUID.randomUUID().toString();
@@ -1103,7 +1099,11 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
 
         String callbackUrl = getCallbackUrlFromInitialRequestParamMap(context);
         if (StringUtils.isBlank(callbackUrl)) {
-            callbackUrl = resolveCallBackURLForAPIBasedAuthFlow(authenticatorProperties, context);
+            if (Boolean.parseBoolean((String) context.getProperty(IS_API_BASED))) {
+                callbackUrl = resolveCallBackURLForAPIBasedAuthFlow(context);
+            } else {
+                callbackUrl = getCallbackUrl(authenticatorProperties);
+            }
         }
 
         boolean isHTTPBasicAuth = Boolean.parseBoolean(authenticatorProperties.get(OIDCAuthenticatorConstants

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -276,6 +276,22 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         return callbackUrl;
     }
 
+    /**
+     * Resolve the callback URL of the IdP based on authenticator properties and the context.
+     *
+     * @param authenticatorProperties Authenticator properties.
+     * @param context                Authentication context.
+     * @return Callback URL.
+     */
+    protected String resolveCallBackURL(Map<String, String> authenticatorProperties, AuthenticationContext context) {
+
+        String callbackurl = getCallbackUrl(authenticatorProperties);
+        if (Boolean.parseBoolean((String) context.getProperty(IS_API_BASED))) {
+            callbackurl = (String) context.getProperty(REDIRECT_URL);
+        }
+        return callbackurl;
+    }
+
     protected String getLogoutUrl(Map<String, String> authenticatorProperties) {
 
         return authenticatorProperties.get(OIDCAuthenticatorConstants.IdPConfParams.OIDC_LOGOUT_URL);
@@ -456,11 +472,8 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                 }
                 String clientId = authenticatorProperties.get(OIDCAuthenticatorConstants.CLIENT_ID);
                 String authorizationEP = getOIDCAuthzEndpoint(authenticatorProperties);
-                String callbackurl = getCallbackUrl(authenticatorProperties);
+                String callbackurl = resolveCallBackURL(authenticatorProperties, context);
 
-                if (Boolean.parseBoolean((String) context.getProperty(IS_API_BASED))) {
-                    callbackurl = (String) context.getProperty(REDIRECT_URL);
-                }
                 String state = getStateParameter(request, context, authenticatorProperties);
                 context.setProperty(OIDCAuthenticatorConstants.AUTHENTICATOR_NAME + STATE_PARAM_SUFFIX, state);
                 String nonce = UUID.randomUUID().toString();
@@ -1088,11 +1101,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
 
         String callbackUrl = getCallbackUrlFromInitialRequestParamMap(context);
         if (StringUtils.isBlank(callbackUrl)) {
-            if (Boolean.parseBoolean((String) context.getProperty(IS_API_BASED))) {
-                callbackUrl = (String) context.getProperty(REDIRECT_URL);
-            } else {
-                callbackUrl = getCallbackUrl(authenticatorProperties);
-            }
+            callbackUrl = resolveCallBackURL(authenticatorProperties, context);
         }
 
         boolean isHTTPBasicAuth = Boolean.parseBoolean(authenticatorProperties.get(OIDCAuthenticatorConstants

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -277,13 +277,15 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
     }
 
     /**
-     * Resolve the callback URL of the IdP based on authenticator properties and the context.
+     * Resolve the callback URL of the IdP, based on authenticator properties and the context properties
+     * to use in the API based authentication flow.
      *
      * @param authenticatorProperties Authenticator properties.
      * @param context                Authentication context.
-     * @return Callback URL.
+     * @return Callback URL to be used in API based authentication flow.
      */
-    protected String resolveCallBackURL(Map<String, String> authenticatorProperties, AuthenticationContext context) {
+    protected String resolveCallBackURLForAPIBasedAuthFlow(Map<String, String> authenticatorProperties,
+                                                           AuthenticationContext context) {
 
         String callbackurl = getCallbackUrl(authenticatorProperties);
         if (Boolean.parseBoolean((String) context.getProperty(IS_API_BASED))) {
@@ -472,7 +474,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                 }
                 String clientId = authenticatorProperties.get(OIDCAuthenticatorConstants.CLIENT_ID);
                 String authorizationEP = getOIDCAuthzEndpoint(authenticatorProperties);
-                String callbackurl = resolveCallBackURL(authenticatorProperties, context);
+                String callbackurl = resolveCallBackURLForAPIBasedAuthFlow(authenticatorProperties, context);
 
                 String state = getStateParameter(request, context, authenticatorProperties);
                 context.setProperty(OIDCAuthenticatorConstants.AUTHENTICATOR_NAME + STATE_PARAM_SUFFIX, state);
@@ -1101,7 +1103,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
 
         String callbackUrl = getCallbackUrlFromInitialRequestParamMap(context);
         if (StringUtils.isBlank(callbackUrl)) {
-            callbackUrl = resolveCallBackURL(authenticatorProperties, context);
+            callbackUrl = resolveCallBackURLForAPIBasedAuthFlow(authenticatorProperties, context);
         }
 
         boolean isHTTPBasicAuth = Boolean.parseBoolean(authenticatorProperties.get(OIDCAuthenticatorConstants


### PR DESCRIPTION
### Proposed changes in this pull request

- Add a protected method named `resolveCallBackURLForAPIBasedAuthFlow ` to resolve the callback in the API_BASED authentication flow.

- Changing the callback URL to the client application's callback URL in  `initiateAuthenticationRequest` method and `getAccessTokenRequest` could affect the OIDC authenticators used for internal purposes.

- resolveCallBackURLForAPIBasedAuthFlow method gives the capability to override the behavior in other authenticators if required.

Part of the first issue of https://github.com/wso2/product-is/issues/19668