### PR TITLE
Enable PKCE in OIDC federated login flow

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/pom.xml
@@ -216,6 +216,7 @@
                         --add-opens java.base/sun.nio.fs=ALL-UNNAMED
                         --add-opens java.base/sun.nio.cs=ALL-UNNAMED
                         --add-opens java.base/sun.net.www.protocol.https=ALL-UNNAMED
+                        --add-opens java.base/java.security=ALL-UNNAMED
                     </argLine>
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
@@ -89,8 +89,8 @@ public class OIDCAuthenticatorConstants {
      * This class holds the constants related to authenticator configuration parameters.
      */
     
-    public static final String OAUTH_FEDERATED_PKCE_CODE_VERIFIER = "OAUTH_PKCE_CODE_VERIFIER";
-    public static final String ENABLE_FEDERATED_PKCE = "IsPKCEEnabled";
+    public static final String PKCE_CODE_VERIFIER = "PKCE_CODE_VERIFIER";
+    public static final String IS_PKCE_ENABLED = "IsPKCEEnabled";
 
     public class AuthenticatorConfParams {
 

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
@@ -88,6 +88,10 @@ public class OIDCAuthenticatorConstants {
     /**
      * This class holds the constants related to authenticator configuration parameters.
      */
+    
+    public static final String OAUTH_FEDERATED_PKCE_CODE_VERIFIER = "OAUTH_PKCE_CODE_VERIFIER";
+    public static final String ENABLE_FEDERATED_PKCE = "IsPKCEEnabled";
+
     public class AuthenticatorConfParams {
 
         private AuthenticatorConfParams() {

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -96,6 +96,9 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -514,6 +517,8 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                 context.setProperty(OIDCAuthenticatorConstants.AUTHENTICATOR_NAME + STATE_PARAM_SUFFIX, state);
                 String nonce = UUID.randomUUID().toString();
                 context.setProperty(OIDC_FEDERATION_NONCE, nonce);
+                boolean isPKCEEnabled = Boolean.parseBoolean(
+                        authenticatorProperties.get(OIDCAuthenticatorConstants.ENABLE_FEDERATED_PKCE));
 
                 OAuthClientRequest authzRequest;
 
@@ -583,6 +588,18 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
 
                 if (StringUtils.isNotBlank(domain)) {
                     loginPage = loginPage + "&fidp=" + domain;
+                }
+
+                // If PKCE is enabled, add code_challenge and code_challenge_method to the request.
+                if (isPKCEEnabled) {
+                    String codeVerifier = generateCodeVerifier();
+                    context.setProperty(OIDCAuthenticatorConstants.OAUTH_FEDERATED_PKCE_CODE_VERIFIER, codeVerifier);
+                    try {
+                        String codeChallenge = generateCodeChallenge(codeVerifier);
+                        loginPage += "&code_challenge=" + codeChallenge + "&code_challenge_method=S256";
+                    } catch (NoSuchAlgorithmException e) {
+                        LOG.error("Error while generating the code challenge", e);
+                    }
                 }
 
                 if (StringUtils.isNotBlank(queryString)) {
@@ -1467,6 +1484,9 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         String clientId = authenticatorProperties.get(OIDCAuthenticatorConstants.CLIENT_ID);
         String clientSecret = authenticatorProperties.get(OIDCAuthenticatorConstants.CLIENT_SECRET);
         String tokenEndPoint = getTokenEndpoint(authenticatorProperties);
+        boolean isPKCEEnabled = Boolean.parseBoolean(
+                authenticatorProperties.get(OIDCAuthenticatorConstants.ENABLE_FEDERATED_PKCE));
+        Object codeVerifier = context.getProperty(OIDCAuthenticatorConstants.OAUTH_FEDERATED_PKCE_CODE_VERIFIER);
 
         String callbackUrl = getCallbackUrlFromInitialRequestParamMap(context);
         if (StringUtils.isBlank(callbackUrl)) {
@@ -1489,9 +1509,21 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                             "authentication scheme.");
                 }
 
-                accessTokenRequest = OAuthClientRequest.tokenLocation(tokenEndPoint).setGrantType(GrantType
-                        .AUTHORIZATION_CODE).setRedirectURI(callbackUrl).setCode(authzResponse.getCode())
-                        .buildBodyMessage();
+                OAuthClientRequest.TokenRequestBuilder tokenRequestBuilder = OAuthClientRequest
+                        .tokenLocation(tokenEndPoint)
+                        .setGrantType(GrantType.AUTHORIZATION_CODE)
+                        .setRedirectURI(callbackUrl)
+                        .setCode(authzResponse.getCode());
+
+                if (isPKCEEnabled) {
+                    if (codeVerifier != null) {
+                        tokenRequestBuilder.setParameter("code_verifier", codeVerifier.toString());
+                    } else {
+                        LOG.warn("PKCE is enabled, but the code verifier is not found.");
+                    }
+                }
+
+                accessTokenRequest = tokenRequestBuilder.buildBodyMessage();
                 String base64EncodedCredential = new String(Base64.encodeBase64((clientId + ":" +
                         clientSecret).getBytes()));
                 accessTokenRequest.addHeader(OAuth.HeaderType.AUTHORIZATION, "Basic " + base64EncodedCredential);
@@ -1501,10 +1533,23 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
                     LOG.debug("Authenticating to token endpoint: " + tokenEndPoint + " including client credentials "
                             + "in request body.");
                 }
-                accessTokenRequest = OAuthClientRequest.tokenLocation(tokenEndPoint).setGrantType(GrantType
-                        .AUTHORIZATION_CODE).setClientId(clientId).setClientSecret(clientSecret).setRedirectURI
-                        (callbackUrl).setCode(authzResponse.getCode()).buildBodyMessage();
+                OAuthClientRequest.TokenRequestBuilder tokenRequestBuilder = OAuthClientRequest
+                        .tokenLocation(tokenEndPoint)
+                        .setGrantType(GrantType.AUTHORIZATION_CODE)
+                        .setClientId(clientId)
+                        .setClientSecret(clientSecret)
+                        .setRedirectURI(callbackUrl)
+                        .setCode(authzResponse.getCode());
+                if (isPKCEEnabled) {
+                    if (codeVerifier != null) {
+                        tokenRequestBuilder.setParameter("code_verifier", codeVerifier.toString());
+                    } else {
+                        LOG.warn("PKCE is enabled, but the code verifier is not found.");
+                    }
+                }
+                accessTokenRequest = tokenRequestBuilder.buildBodyMessage();
             }
+            context.removeProperty(OIDCAuthenticatorConstants.OAUTH_FEDERATED_PKCE_CODE_VERIFIER);
             // set 'Origin' header to access token request.
             if (accessTokenRequest != null) {
                 // fetch the 'Hostname' configured in carbon.xml
@@ -1522,7 +1567,6 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         } catch (URLBuilderException e) {
             throw new RuntimeException("Error occurred while building URL in tenant qualified mode.", e);
         }
-
         return accessTokenRequest;
     }
 
@@ -1691,6 +1735,15 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         enableBasicAuth.setType("boolean");
         enableBasicAuth.setDisplayOrder(10);
         configProperties.add(enableBasicAuth);
+
+        Property enablePKCE = new Property();
+        enablePKCE.setName("isPKCEEnabled");
+        enablePKCE.setDisplayName("Enable PKCE");
+        enablePKCE.setRequired(false);
+        enablePKCE.setDescription("Specifies that PKCE should be used for client authentication");
+        enablePKCE.setType("boolean");
+        enablePKCE.setDisplayOrder(10);
+        configProperties.add(enablePKCE);
 
         return configProperties;
     }
@@ -2146,5 +2199,34 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
             return StringUtils.EMPTY;
         }
         return context.getExternalIdP().getIdPName();
+    }
+
+    /**
+     * Generate code verifier for PKCE
+     *
+     * @return code verifier
+     */
+    private String generateCodeVerifier() {
+        SecureRandom secureRandom = new SecureRandom();
+        byte[] codeVerifier = new byte[32];
+        secureRandom.nextBytes(codeVerifier);
+        return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(codeVerifier);
+    }
+
+    /**
+     * Generate code challenge for PKCE
+     *
+     * @param codeVerifier code verifier
+     * @return code challenge
+     * @throws UnsupportedEncodingException
+     * @throws NoSuchAlgorithmException
+     */
+    private String generateCodeChallenge(String codeVerifier)
+            throws UnsupportedEncodingException, NoSuchAlgorithmException {
+        byte[] bytes = codeVerifier.getBytes("US-ASCII");
+        MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
+        messageDigest.update(bytes, 0, bytes.length);
+        byte[] digest = messageDigest.digest();
+        return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -482,7 +482,7 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
     public void testPassProcessAuthenticationResponse() throws Exception {
 
         setupTest();
-
+        authenticatorProperties.put(OIDCAuthenticatorConstants.IS_PKCE_ENABLED, "false");
         IdentityProviderProperty property = new IdentityProviderProperty();
         property.setName(IdPManagementConstants.IS_TRUSTED_TOKEN_ISSUER);
         property.setValue("false");
@@ -523,6 +523,7 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
         when(mockAuthenticationContext.getExternalIdP()).thenReturn(externalIdPConfig);
         when(externalIdPConfig.getIdentityProvider()).thenReturn(identityProvider);
         when(identityProvider.getIdpProperties()).thenReturn(identityProviderProperties);
+        authenticatorProperties.put(OIDCAuthenticatorConstants.IS_PKCE_ENABLED, "false");
         when(openIDConnectAuthenticatorDataHolder.getClaimMetadataManagementService()).thenReturn
                 (claimMetadataManagementService);
         when(mockAuthenticationContext.getExternalIdP()).thenReturn(externalIdPConfig);
@@ -550,19 +551,17 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
     @Test()
     public void testGetAccessTokenRequestWithPKCE() throws URLBuilderException, AuthenticationFailedException {
         mockAuthenticationRequestContext(mockAuthenticationContext);
-        mockAuthenticationContext.getAuthenticatorProperties()
-                .put(OIDCAuthenticatorConstants.ENABLE_FEDERATED_PKCE, "true");
-        when(mockAuthenticationContext.getProperty(OIDCAuthenticatorConstants.OAUTH_FEDERATED_PKCE_CODE_VERIFIER))
+        authenticatorProperties.put(OIDCAuthenticatorConstants.IS_PKCE_ENABLED, "true");
+        when(mockAuthenticationContext.getProperty(OIDCAuthenticatorConstants.PKCE_CODE_VERIFIER))
                 .thenReturn("sample_code_verifier");
-        OAuthAuthzResponse oAuthAuthzResponse = mock(OAuthAuthzResponse.class);
-        when(oAuthAuthzResponse.getCode()).thenReturn("abc");
+        when(mockOAuthzResponse.getCode()).thenReturn("abc");
         mockStatic(ServiceURLBuilder.class);
         ServiceURLBuilder serviceURLBuilder = mock(ServiceURLBuilder.class);
         when(ServiceURLBuilder.create()).thenReturn(serviceURLBuilder);
         when(serviceURLBuilder.build()).thenReturn(serviceURL);
         when(serviceURL.getAbsolutePublicURL()).thenReturn("http://localhost:9443");
         OAuthClientRequest request = openIDConnectAuthenticator
-                .getAccessTokenRequest(mockAuthenticationContext, oAuthAuthzResponse);
+                .getAccessTokenRequest(mockAuthenticationContext, mockOAuthzResponse);
         assertTrue(request.getBody().contains("code_verifier=sample_code_verifier"));
     }
 
@@ -585,6 +584,7 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
 
         setupTest();
         authenticatorProperties.put("callbackUrl", " ");
+        authenticatorProperties.put(OIDCAuthenticatorConstants.IS_PKCE_ENABLED, "false");
         mockStatic(IdentityUtil.class);
         when(IdentityUtil.getServerURL(FrameworkConstants.COMMONAUTH, true, true))
                 .thenReturn("http:/localhost:9443/oauth2/callback");
@@ -645,6 +645,7 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
         setupTest();
         when(LoggerUtils.isDiagnosticLogsEnabled()).thenReturn(true);
         authenticatorProperties.put("callbackUrl", "http://localhost:8080/playground2/oauth2client");
+        authenticatorProperties.put(OIDCAuthenticatorConstants.IS_PKCE_ENABLED, "false");
         Map<String, String> paramMap = new HashMap<>();
         paramMap.put("redirect_uri", "http:/localhost:9443/oauth2/redirect");
         when(mockAuthenticationContext.getProperty(OIDC_PARAM_MAP_STRING)).thenReturn(paramMap);


### PR DESCRIPTION
### Proposed changes in this pull request

This PR enables PKCE in OIDC federated login flow. In IDP configurations, a new checkbox has been introduced under Federated configurations to enable/disable PKCE in PR[1] and upon enabling the checkbox respective `code_verifier` and `code_challenge` parameters are added to the authentication and token requests.

Related to https://github.com/wso2/api-manager/issues/1613

[1] https://github.com/wso2/carbon-identity-framework/pull/4500