### PR TITLE
Fix callback url resolving logic for api based authn

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -316,7 +316,7 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
     @Test
     public void testGetCallbackUrl() throws IOException {
 
-        assertEquals(openIDConnectAuthenticator.getCallBackURL(authenticatorProperties),
+        assertEquals(openIDConnectAuthenticator.getCallbackUrl(authenticatorProperties, mockAuthenticationContext),
                 "http://localhost:8080/playground2/oauth2client",
                 "Callback URL is not valid.");
     }
@@ -359,7 +359,7 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
     @Test
     public void testGetCallBackURL() throws IOException {
 
-        assertEquals(openIDConnectAuthenticator.getCallBackURL(authenticatorProperties),
+        assertEquals(openIDConnectAuthenticator.getCallbackUrl(authenticatorProperties, mockAuthenticationContext),
                 "http://localhost:8080/playground2/oauth2client",
                 "Callback URL is not valid.");
     }


### PR DESCRIPTION
This PR improves the callback URL resolving logic so that in api based authentication flow the redirect url will be set as the callback url instead of the callback url set in connector properties.

Related issue - https://github.com/wso2/product-is/issues/20173