### PR TITLE
Change authenticator property keys to be specific for different authenticators

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -668,6 +668,12 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         }
     }
 
+    /**
+     * This method can be used to add the authentication error message content into the context.
+     *
+     * @param errorMessage  ErrorMessage object.
+     * @param context       AuthenticationContext.
+     */
     protected static void setAuthenticatorMessageToContext(ErrorMessages errorMessage,
                                                            AuthenticationContext context) {
 

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -629,7 +629,8 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
         when(identityProvider.getIdpProperties()).thenReturn(identityProviderProperties);
         whenNew(OAuthClient.class).withAnyArguments().thenReturn(mockOAuthClient);
         when(mockOAuthClient.accessToken(any())).thenReturn(mockOAuthJSONAccessTokenResponse);
-        when(mockAuthenticationContext.getProperty(OIDC_FEDERATION_NONCE)).thenReturn(invalidNonce);
+        String nonceKey = openIDConnectAuthenticator.getName() + OIDC_FEDERATION_NONCE;
+        when(mockAuthenticationContext.getProperty(nonceKey)).thenReturn(invalidNonce);
         when(mockOAuthJSONAccessTokenResponse.getParam(anyString())).thenReturn(idToken);
 
         Assert.assertThrows(
@@ -1082,7 +1083,8 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
         when(externalIdPConfig.getIdentityProvider()).thenReturn(identityProvider);
         when(identityProvider.getIdpProperties()).thenReturn(identityProviderProperties);
         when(mockAuthenticationContext.getAuthenticationRequest()).thenReturn(mockAuthenticationRequest);
-        when(mockAuthenticationContext.getProperty(OIDC_FEDERATION_NONCE)).thenReturn(nonce);
+        String nonceKey = openIDConnectAuthenticator.getName() + OIDC_FEDERATION_NONCE;
+        when(mockAuthenticationContext.getProperty(nonceKey)).thenReturn(nonce);
         when(mockAuthenticationContext.getAuthenticatorProperties()).thenReturn(authenticatorProperties);
         authenticatorProperties.put(OIDCAuthenticatorConstants.CLIENT_ID, clientId);
 


### PR DESCRIPTION
When adding the properties such as redirect_url, scope, state and nonce into the authentication context, use the specific authenticator name as the prefix to uniquely identify the specific keys according to each authenticator.

Related issue:
- https://github.com/wso2/product-is/issues/20584