### PR TITLE
Decode dynamic query parameters when fetching from the multiOptionURI

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -2086,7 +2086,7 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
             for (String queryParam: queryParams) {
                 String[] queryParamComponents = queryParam.split(QUERY_PARAM_KEY_VALUE_DELIMITER);
                 if (queryParamComponents.length == 2 && queryParamComponents[0].equalsIgnoreCase(parameterName)) {
-                    return queryParamComponents[1];
+                    return URLDecoder.decode(queryParamComponents[1], StandardCharsets.UTF_8);
                 }
             }
         }


### PR DESCRIPTION
### Purpose
The getParameterFromURIString method is responsible for retrieving dynamic query parameters of the IDP from the multiOptionURI when redirecting from the multi-option page. However, since the multiOptionURI parameter is encoded, it must be decoded before extracting the parameters. Failing to do so can alter the original values of the dynamic parameters

### Related issue
- https://github.com/wso2/product-is/issues/22859