### PR TITLE
Remove auth session data in backchannel logout

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/logout/idpinit/processor/FederatedIdpInitLogoutProcessor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/logout/idpinit/processor/FederatedIdpInitLogoutProcessor.java
@@ -59,6 +59,7 @@ import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 
 import java.text.ParseException;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -190,6 +191,7 @@ public class FederatedIdpInitLogoutProcessor extends IdentityProcessor {
                     OpenIDConnectAuthenticatorDataHolder.getInstance().getServerSessionManagementService();
             serverSessionManagementService.removeSession(sessionId);
             removeFederatedIDPSessionMapping(sessionId);
+            removeTerminatedSessionRecords(sessionId);
             if (log.isDebugEnabled()) {
                 log.debug("Session terminated for session Id: " + sessionId);
             }
@@ -726,5 +728,10 @@ public class FederatedIdpInitLogoutProcessor extends IdentityProcessor {
         } catch (UserSessionException e) {
             throw new LogoutServerException("Exception occurred while removing federated IDP session mapping.");
         }
+    }
+
+    private void removeTerminatedSessionRecords(String sessionId) {
+
+        UserSessionStore.getInstance().removeTerminatedSessionRecords(Collections.singletonList(sessionId));
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/logout/idpinit/processor/FederatedIdpInitLogoutProcessorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/logout/idpinit/processor/FederatedIdpInitLogoutProcessorTest.java
@@ -73,8 +73,12 @@ import javax.sql.DataSource;
 import javax.xml.stream.XMLInputFactory;
 
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.testng.Assert.assertEquals;
@@ -501,11 +505,17 @@ public class FederatedIdpInitLogoutProcessorTest extends PowerMockTestCase {
         // Mock removeSession method.
         when(serverSessionManagementService.removeSession(SESSION_CONTEXT_KEY)).thenReturn(true);
 
+        mockStatic(UserSessionStore.class);
+        UserSessionStore userSessionStore = mock(UserSessionStore.class);
+        when(UserSessionStore.getInstance()).thenReturn(userSessionStore);
+        doNothing().when(userSessionStore).removeTerminatedSessionRecords(anyList());
+
         // Mock tenantID.
         mockStatic(IdentityTenantUtil.class);
         when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
 
         assertNotNull(logoutProcessor.handleOIDCFederatedLogoutRequest(mockLogoutRequest));
+        verify(userSessionStore, times(1)).removeTerminatedSessionRecords(anyList());
     }
 
     @Test


### PR DESCRIPTION
### Proposed changes in this pull request
Currently in federated IDP initiated backchannel logout using SID claim, the session data store data and federated user session mapping data is removed but auth user session data is not removed. With this PR, auth user session data are also removed when executing the backchannel logout.

Related Issue - https://github.com/wso2/product-is/issues/23024