### PR TITLE
Upgrade json-smart version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
 
         <carbon.identity.framework.version>5.25.90</carbon.identity.framework.version>
         <oltu.version>1.0.0.wso2v3</oltu.version>
-        <json-smart.version>2.5.0</json-smart.version>
+        <json-smart.version>2.5.2</json-smart.version>
         <json.wso2.version>3.0.0.wso2v1</json.wso2.version>
         <carbon.kernel.version>4.9.0</carbon.kernel.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>


### PR DESCRIPTION
### Purpose
To upgrade json-smart version from 2.5.0 to the non-vulnerable 2.5.2 version.

#### Related PRs:

Identity-inbound-auth-oauth: https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2730
Carbon-identity-framework: https://github.com/wso2/carbon-identity-framework/pull/6543
Identity-inbound-auth-openid: https://github.com/wso2-extensions/identity-inbound-auth-openid/pull/109
Carbon-mediation: https://github.com/wso2/carbon-mediation/pull/1767
Carbon-analytics-common: https://github.com/wso2/carbon-analytics-common/pull/862
Carbon-apimgt: https://github.com/wso2/carbon-apimgt/pull/12953
Product-apim: https://github.com/wso2/product-apim/pull/13688
