### PR TITLE
modify the OpenIDConnectAuthenticator.buildClaimMappings method to also handle the ArrayList type as an array

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -1495,7 +1495,19 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         if (StringUtils.isBlank(separator)) {
             separator = IdentityCoreConstants.MULTI_ATTRIBUTE_SEPARATOR_DEFAULT;
         }
-        if (entry.getValue() instanceof JSONArray) {
+        if (entry.getValue() instanceof ArrayList) {
+            ArrayList<?> jsonArray = (ArrayList<?>) entry.getValue();
+            if (jsonArray != null && !jsonArray.isEmpty()) {
+                Iterator attributeIterator = jsonArray.iterator();
+                while (attributeIterator.hasNext()) {
+                    if (claimValue == null) {
+                        claimValue = new StringBuilder(attributeIterator.next().toString());
+                    } else {
+                        claimValue.append(separator).append(attributeIterator.next().toString());
+                    }
+                }
+            }
+        } if (entry.getValue() instanceof JSONArray) {
             JSONArray jsonArray = (JSONArray) entry.getValue();
             if (jsonArray != null && !jsonArray.isEmpty()) {
                 Iterator attributeIterator = jsonArray.iterator();


### PR DESCRIPTION
### Proposed changes in this pull request

When we configure Azure Entra ID as an OIDC IdP, wso2am does not correctly map the OIDC ID Token `roles` claim to the user profile `Roles` property.

For example, when wso2am receives this ID Token:

```json
{
  "aud": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeee0000",
  "iss": "https://login.microsoftonline.com/aaaaaaaa-bbbb-cccc-dddd-eeeeeeee0001/v2.0",
  "iat": 1,
  "nbf": 1,
  "exp": 1,
  "email": "john.doe@example.com",
  "name": "John Doe",
  "oid": "x",
  "preferred_username": "john.doe@example.com",
  "rh": "x",
  "roles": [
    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", // test-a
    "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", // test-b
    "cccccccc-cccc-cccc-cccc-cccccccccccc"  // test-c
  ],
  "sid": "x",
  "sub": "x",
  "tid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeee0001",
  "uti": "x",
  "ver": "2.0"
}
```

And wso2am is configured to map the `cccccccc-cccc-cccc-cccc-cccccccccccc` role claim to `test-c`, the associated `Roles` user profile property, will end-up with that array being converted to a single string as (notice the `[` stray char):

```
aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa,[bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb,test-c
```

Instead of being:

```
aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa,bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb,test-c
```

This happens because there is a type confusion in the [OpenIDConnectAuthenticator.buildClaimMappings function](https://github.com/wso2-extensions/identity-outbound-auth-oidc/blob/v5.11.34/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java#L766).

When that function is called to handle the `roles` ID Token property, its `Map.Entry<String, Object> entry` parameter receives `ArrayList` value object instead of a `JSONArray`, as such, the value is converted to a string using `ArrayList.toString`, and that will convert the array to the `[aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa, bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb, cccccccc-cccc-cccc-cccc-cccccccccccc]` string. But, later code expects that a multi-value claim to be serialized as `aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa,bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb,cccccccc-cccc-cccc-cccc-cccccccccccc` (a comma separated string), so the final `roles` that ends-up in the wso2am user profile is broken, and by extension, the claims mapping is also broken, as its executes without actually doing any mapping.

### When should this PR be merged

Not sure whether the `JSONArray` type should be handled at all. Maybe it should for backwards compatibility?

Also, not sure whether we should check for the [Iterable interface type](https://docs.oracle.com/javase/8/docs/api/java/lang/Iterable.html) instead.

So, please advise, and I will change this PR.

### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
