### PR TITLE
Add multiOptionURI parsing for additional query params

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
@@ -49,6 +49,10 @@ public class OIDCAuthenticatorConstants {
     public static final String POST_LOGOUT_REDIRECT_URI = "post_logout_redirect_uri";
     public static final String ID_TOKEN_HINT = "id_token_hint";
 
+    public static final String MULTI_OPTION_URI = "multiOptionURI";
+    public static final String URI_QUERY_PARAM_DELIMITER = "&";
+    public static final String QUERY_PARAM_KEY_VALUE_DELIMITER = "=";
+
     public static final String AUTH_PARAM = "$authparam";
     public static final String DYNAMIC_AUTH_PARAMS_LOOKUP_REGEX = "\\$authparam\\{(\\w+)\\}";
 


### PR DESCRIPTION
Issue:
- https://github.com/wso2-enterprise/wso2-iam-internal/issues/3429

When configuring the authentication steps for a service provider, if the first step has multiple authentication choices between with an OIDC federated IdP as one of them, when the user picks the federated IdP, they are redirected to the federated IdP's login page to proceed. 

When this redirection happens, the URL query parameters originally included in the request are encoded and included in the request as a parameter called multiOptionURI. 

When parsing the request's query parameters to interpret the additional query parameters, the encoded value of multiOptionURI is not considered.

With this PR, if the additional query parameter isn't present in the request parameters, it will check if the multiOptionURI parameter is available and check if the additional query parameter is present here instead.

Public PRs:
- https://github.com/wso2-extensions/identity-outbound-auth-oidc/pull/191
- https://github.com/wso2-extensions/identity-outbound-auth-oidc/pull/197