### PR TITLE
Unexpected behavior when passing empty values to authenticatorParams in Adaptive Auth

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -2126,8 +2126,8 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
 
         Matcher matcher = Pattern.compile(OIDCAuthenticatorConstants.DYNAMIC_AUTH_PARAMS_LOOKUP_REGEX)
                 .matcher(queryString);
-        String value = "";
         while (matcher.find()) {
+            String value = "";
             String paramName = matcher.group(1);
             if (StringUtils.isNotEmpty(getRuntimeParams(context).get(paramName))) {
                 value = getRuntimeParams(context).get(paramName);


### PR DESCRIPTION
Issue: 
- https://github.com/wso2/product-is/issues/23686

This resolves the issue where, when multiple custom parameters are passed, an empty value is replaced by neighboring values instead of being passed as an empty value.