### PR TITLE
Unexpected behavior when passing empty values to authenticatorParams in Adaptive Auth

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -1127,8 +1127,8 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
 
         Matcher matcher = Pattern.compile(OIDCAuthenticatorConstants.DYNAMIC_AUTH_PARAMS_LOOKUP_REGEX)
                 .matcher(queryString);
-        String value = "";
         while (matcher.find()) {
+            String value = "";
             String paramName = matcher.group(1);
             if (StringUtils.isNotEmpty(getRuntimeParams(context).get(paramName))) {
                 value = getRuntimeParams(context).get(paramName);

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -175,6 +175,9 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
         authenticatorParamProperties = new HashMap<>();
         authenticatorParamProperties.put("username", "testUser");
         authenticatorParamProperties.put("fidp", "google");
+        authenticatorParamProperties.put("param01", "value1");
+        authenticatorParamProperties.put("param02", "");
+        authenticatorParamProperties.put("param03", "value3");
         token = null;
 
     }
@@ -362,6 +365,18 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
         assertEquals(Whitebox.invokeMethod(openIDConnectAuthenticator,
                 "getQueryStringWithAuthenticatorParam", mockAuthenticationContext,
                 "login_hint=$authparam{username}&domain=$authparam{fidp}"), "login_hint=testUser&domain=google");
+    }
+
+    @Test
+    public void testGetQueryStringWithMultipleAuthenticatorParamsIncludingEmptyValue() throws Exception {
+
+        mockAuthenticationRequestContext(mockAuthenticationContext);
+        when(openIDConnectAuthenticator.getRuntimeParams(mockAuthenticationContext)).
+                thenReturn(authenticatorParamProperties);
+        assertEquals(Whitebox.invokeMethod(openIDConnectAuthenticator,
+                "getQueryStringWithAuthenticatorParam", mockAuthenticationContext,
+                "param01=$authparam{param01}&param02=$authparam{param02}&param03=$authparam{param03}"),
+                "param01=value1&param02=&param03=value3");
     }
 
     @Test(expectedExceptions = AuthenticationFailedException.class)


### PR DESCRIPTION
Issue:
- https://github.com/wso2-enterprise/wso2-iam-internal/issues/3505

This resolves the issue where, when multiple custom parameters are passed, an empty value is replaced by neighboring values instead of being passed as an empty value.

Public PR:
- https://github.com/wso2-extensions/identity-outbound-auth-oidc/pull/206