### PR TITLE
[5.14.x][APIM] Add config to override non-user claims filtering

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OIDCAuthenticatorConstants.java
@@ -66,6 +66,7 @@ public class OIDCAuthenticatorConstants {
         }
 
         public static final String DEFAULT_IDP_CONFIG = "DefaultIdPConfig";
+        public static final String EXCLUDED_CLAIM_ATTRIBUTES = "excludedClaimAttributes";
     }
 
     public class IdPConfParams {

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticator.java
@@ -74,6 +74,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -524,9 +525,10 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
 
             String authenticatedUserId = getAuthenticatedUserId(context, oAuthResponse, jwtAttributeMap);
             String attributeSeparator = getMultiAttributeSeparator(context, authenticatedUserId);
+            String[] excludedAttributes = getExcludedClaimAttributes();
 
             jwtAttributeMap.entrySet().stream()
-                    .filter(entry -> !ArrayUtils.contains(NON_USER_ATTRIBUTES, entry.getKey()))
+                    .filter(entry -> !ArrayUtils.contains(excludedAttributes, entry.getKey()))
                     .forEach(entry -> buildClaimMappings(claimsMap, entry, attributeSeparator));
 
             authenticatedUser = AuthenticatedUser
@@ -1259,5 +1261,40 @@ public class OpenIDConnectAuthenticator extends AbstractApplicationAuthenticator
         }
 
         return null;
+    }
+
+    /**
+     * Get the list of claim attributes to be excluded from user attributes.
+     * If configured in application-authentication.xml, returns the configured list.
+     * Otherwise, returns the default list.
+     *
+     * @return Array of claim attributes to exclude.
+     */
+    private String[] getExcludedClaimAttributes() {
+
+        String configuredAttributes = getAuthenticatorConfig().getParameterMap()
+                .get(OIDCAuthenticatorConstants.AuthenticatorConfParams.EXCLUDED_CLAIM_ATTRIBUTES);
+        
+        if (configuredAttributes == null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Using default non-user attributes as excluded claim attributes.");
+            }
+            return NON_USER_ATTRIBUTES;
+        }
+        
+        if (configuredAttributes.isBlank()) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Using empty array for excluded claim attributes.");
+            }
+            return new String[0];
+        }
+        
+        String[] attributes = Arrays.stream(configuredAttributes.split(","))
+                .map(String::trim)
+                .toArray(String[]::new);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Using configured excluded claim attributes: " + configuredAttributes);
+        }
+        return attributes;
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/test/java/org/wso2/carbon/identity/application/authenticator/oidc/OpenIDConnectAuthenticatorTest.java
@@ -18,9 +18,9 @@
 
 package org.wso2.carbon.identity.application.authenticator.oidc;
 
+import com.ctc.wstx.stax.WstxInputFactory;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.LogFactory;
 import org.apache.oltu.oauth2.client.OAuthClient;
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest;
 import org.apache.oltu.oauth2.client.response.OAuthAuthzResponse;
@@ -30,6 +30,7 @@ import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.mockito.Matchers;
 import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.powermock.reflect.Whitebox;
@@ -39,6 +40,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.ExternalIdPConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
@@ -68,6 +70,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.xml.stream.XMLInputFactory;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
@@ -86,9 +89,11 @@ import static org.testng.Assert.assertTrue;
 /***
  * Unit test class for OpenIDConnectAuthenticatorTest class.
  */
-@PrepareForTest({LogFactory.class, OAuthClient.class, URL.class, FrameworkUtils.class,
+@PrepareForTest({OAuthClient.class, URL.class, FrameworkUtils.class,
         OpenIDConnectAuthenticatorDataHolder.class, OAuthAuthzResponse.class, OAuthClientRequest.class,
-        OAuthClientResponse.class, IdentityUtil.class, OpenIDConnectAuthenticator.class, ServiceURLBuilder.class})
+        OAuthClientResponse.class, IdentityUtil.class, OpenIDConnectAuthenticator.class, ServiceURLBuilder.class,
+        XMLInputFactory.class})
+@PowerMockIgnore({"org.wso2.carbon.identity.application.authentication.framework.handler.*"})
 public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
 
     @Mock
@@ -636,6 +641,10 @@ public class OpenIDConnectAuthenticatorTest extends PowerMockTestCase {
         when(serviceURLBuilder.addPath(anyString())).thenReturn(serviceURLBuilder);
         when(serviceURLBuilder.addParameter(anyString(), anyString())).thenReturn(serviceURLBuilder);
         when(serviceURLBuilder.build()).thenReturn(serviceURL);
+
+        mockStatic(XMLInputFactory.class);
+        when(XMLInputFactory.newInstance()).thenReturn(new WstxInputFactory());
+        FileBasedConfigurationBuilder.getInstance(TestUtils.getFilePath("application-authentication.xml"));
     }
 
     private void setParametersForOAuthClientResponse(OAuthClientResponse mockOAuthClientResponse,


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/api-manager/issues/4733

## Issue
The OIDC authenticator previously used a hardcoded set of non-user JWT attributes (at_hash, iss, iat, exp, aud, azp) that were always filtered out during claim mapping in `processAuthenticationResponse`.  A customer wanted to override this list due to a migration issue

## Approach
Support configuring the excluded claim attributes via the deployment.toml file, while keeping the hardcoded list as the default. 

If the following config is added, only the defined attributed will be filtered out. 
```
[authentication.authenticator.oidc.parameters]
excludedClaimAttributes="at_hash,iss,iat,exp,aud,azp"
```

If no config is given, it will use the hardcoded `NON_USER_ATTRIBUTES` for filtering out.
