### PR TITLE
Specify SunJSSE provider for SSLContext

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/CustomURLConnectionClient.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/CustomURLConnectionClient.java
@@ -68,7 +68,7 @@ public class CustomURLConnectionClient implements HttpClient {
                 // Use default JVM truststore (same behavior as HttpsURLConnection defaults)
                 tmf.init((KeyStore) null);
 
-                SSLContext sc = SSLContext.getInstance("TLS");
+                SSLContext sc = SSLContext.getInstance("TLS", "SunJSSE");
                 // KeyManagers = null => no client certificate will ever be presented
                 sc.init(null, tmf.getTrustManagers(), new SecureRandom());
 

--- a/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/CustomURLConnectionClient.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.oidc/src/main/java/org/wso2/carbon/identity/application/authenticator/oidc/CustomURLConnectionClient.java
@@ -63,7 +63,7 @@ public class CustomURLConnectionClient implements HttpClient {
                 HttpsURLConnection https = (HttpsURLConnection) c;
 
                 TrustManagerFactory tmf = TrustManagerFactory.getInstance(
-                        TrustManagerFactory.getDefaultAlgorithm()
+                        TrustManagerFactory.getDefaultAlgorithm(), "SunJSSE"
                 );
                 // Use default JVM truststore (same behavior as HttpsURLConnection defaults)
                 tmf.init((KeyStore) null);


### PR DESCRIPTION
This pull request introduces a minor but important change to the SSL context initialization in the `CustomURLConnectionClient` class. The update specifies the use of the `SunJSSE` security provider when creating the `SSLContext`, which can help ensure compatibility and consistency with Java's default SSL implementation.

Security and compatibility improvement:

* [`CustomURLConnectionClient.java`](diffhunk://#diff-cc7250e66220b29cac4ca9acbe6f3e16c6fd175eca4b676f28bf44f01028b4b5L71-R71): Changed the `SSLContext` initialization to explicitly use the `SunJSSE` provider, instead of relying on the default provider.